### PR TITLE
feature_9/exception:nullを許可しないバリデーション

### DIFF
--- a/NOTE/validation.md
+++ b/NOTE/validation.md
@@ -1,0 +1,38 @@
+# バリデーションエラー
+
+- Controllerのレイヤーで実装する
+- @NotNull、@NotBlank、@Size、@Min、@Emailなど
+- HTTPステータスコード400（Bad Request）を返す
+- @RestControllerAdvice を使用してグローバルなエラーハンドラを実装する
+    - @RestControllerAdviceを使用してアプリケーション全体で発生するエラーをキャッチして処理するための、グローバルなエラーハンドリングを行うことが適切である
+    - `CustomExceptionHandler`は、@RestControllerAdviceを使用して実装した例外ハンドラである
+- MethodArgumentNotValidException をキャッチしてバリデーションエラーを処理する
+
+    - SpringBootでは`MethodArgumentNotValidExceptiton`がスローされた際に実行する
+    - コントローラメソッド（Controllerクラスの@Validが付いているメソッドの引数）が不正な場合に発生する
+    - --> バリデーション情報を取得し、エラーレスポンスを返す
+    - BindingResultを使用しない場合、`MethodArgumentNotValidException`メソッドを使用する
+
+- 気をつけること
+- @Valid
+    - Controllerの引数で使用
+    - @RequestBodyと共に引数の直前に記述し、引数のフィールドに対して、リクエストボディのバリデーションを行う
+    - 主にJava標準のバリデーション（jakarta.validationパッケージ）を実行するために使用
+
+- @Validated
+    - ServiceやControllerクラスのメソッド内の引数）。Spring特有のバリデーションを実行するために使用
+    - Java Bean Validationの場合に使用する
+    - HTTPステータスコード404（Not Found）を返す
+
+# 特定の例外
+
+- Javaのカスタム例外であり、特定の条件やエラーが発生した際に定義する
+- `ResourceNotFoundException`などに対してカスタムなエラーハンドリングを行う
+- @ExceptionHandlerを使用して、個別の例外クラスに対するエラーハンドリングを実装する
+
+    - Controllerクラスのメソッド内でリソースが見つからないなど
+    - --> カスタムな例外をスローする（ResourceNotFoundExceptionなど）
+    - --> 例外をキャッチし、適切なレスポンスを生成する
+    - --> HTTPステータスコード404（Not Found）を返す
+
+- 例外がスローするまで、例外ハンドリングが行われない

--- a/README.md
+++ b/README.md
@@ -29,11 +29,17 @@
 
 ブランチ：feature_#7/update
 
-| 機能            | 説明                         |
-|---------------|----------------------------|
-| Update        | ID5のname,impressionデータ更新する |
-| Delete        | IDを指定して1レコードを削除する          |
-| ErrorHandling | nameに対する制御                 |
+| 機能     | 説明                         |
+|--------|----------------------------|
+| Update | ID5のname,impressionデータ更新する |
+|
+| Delete | IDを指定して1レコードを削除する          |
+
+ブランチ：feature_#9/exception
+
+| 機能            | 説明         |
+|---------------|------------|
+| ErrorHandling | nameに対する制御 |
 
 ## 実装順理由
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,38 +1,39 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.1.5'
-	id 'io.spring.dependency-management' version '1.1.3'
+    id 'java'
+    id 'org.springframework.boot' version '3.1.5'
+    id 'io.spring.dependency-management' version '1.1.3'
 }
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.2'
-	implementation 'org.jetbrains:annotations:24.0.0'
-	implementation 'org.jetbrains:annotations:24.0.0'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.2'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.2'
+    implementation 'org.jetbrains:annotations:24.0.0'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    compileOnly 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.2'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/example/skiresortapi/controller/SkiresortController.java
+++ b/src/main/java/com/example/skiresortapi/controller/SkiresortController.java
@@ -7,9 +7,9 @@ import com.example.skiresortapi.entity.Skiresort;
 import com.example.skiresortapi.exception.ResourceNotFoundException;
 import com.example.skiresortapi.service.SkiresortService;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -75,7 +75,7 @@ public class SkiresortController {
     }
 
     @PatchMapping("/skiresorts/{id}")
-    public ResponseEntity<Map<String, String>> update(@PathVariable("id") int id, @RequestBody @Validated SkiresortUpdateForm form) {
+    public ResponseEntity<Map<String, String>> update(@PathVariable("id") int id, @RequestBody @Valid SkiresortUpdateForm form) {
 
         // id以外のSkiresortUpdateFormの情報を使用してレコードを更新する
         skiresortService.updateSkiresort(id, form.getName(), form.getArea(), form.getImpression());

--- a/src/main/java/com/example/skiresortapi/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/example/skiresortapi/exception/CustomExceptionHandler.java
@@ -1,0 +1,42 @@
+package com.example.skiresortapi.exception;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+// アプリケーション全体で発生するエラーをキャッチして処理するグローバルなエラーハンドリング
+@RestControllerAdvice
+public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request) {
+        MultiValueMap<String, String> invalidParam = new LinkedMultiValueMap<>();
+        for (FieldError e : ex.getFieldErrors()) {
+            invalidParam.add(e.getField(), e.getDefaultMessage());
+        }
+
+        Map<String, Object> body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
+                "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                "message", invalidParam);
+
+        // 400エラーを返す
+        return ResponseEntity.badRequest().body(body);
+    }
+}

--- a/src/main/java/com/example/skiresortapi/mapper/SkiresortMapper.java
+++ b/src/main/java/com/example/skiresortapi/mapper/SkiresortMapper.java
@@ -19,7 +19,7 @@ public interface SkiresortMapper {
     @Select("SELECT * FROM skiresort WHERE id = #{id}")
     Optional<Skiresort> findById(int id);
 
-    @Insert("INSERT INTO skiresort (name, area, impression) VALUES (#{name}, #{area}, #{impression})")
+    @Insert("INSERT INTO skiresort (id, name, area, impression) VALUES (#{id}, #{name}, #{area}, #{impression})")
     // idを自動生成する
     @Options(useGeneratedKeys = true, keyProperty = "id")
     void insertSkiresort(Skiresort skiresort);

--- a/src/main/java/com/example/skiresortapi/service/SkiresortServiceImpl.java
+++ b/src/main/java/com/example/skiresortapi/service/SkiresortServiceImpl.java
@@ -53,5 +53,4 @@ public class SkiresortServiceImpl implements SkiresortService {
 
         this.skiresortMapper.updateSkiresort(skiresort);
     }
-
 }


### PR DESCRIPTION
# validation:nullを許可しないカスタムなバリデーション

### 苦労したこと
バリデーションが効かず、HTTPステータスコード500エラーが返ってきた。
->アノテーションを見直すことで、期待通り400が返された。

### 動作確認ポイント
- nullを指定した場合に期待通りのHTTPレスポンス、メッセージが返されること。

```
{
  "timestamp": "2023-12-20T19:29:29.536273+09:00[Asia/Tokyo]",
  "message": {
    "impression": [
      "null は許可されていません"
    ],
    "name": [
      "null は許可されていません"
    ],
    "area": [
      "null は許可されていません"
    ]
  },
  "error": "Bad Request",
  "status": "400"
}
```

### curlコマンド
```
$ curl --location --request PATCH 'http://localhost:8080/skiresorts/1' \
--header 'Content-Type: application/json' \
--data '{
    "name": null,
    "area": null,
    "customerEvaluation": null
}'
```

### 動作確認キャプチャ
![9DB78CB8-8FDF-4B53-9E26-AAFAF3150C85_4_5005_c](https://github.com/yoko-newDeveloper/skiresortapi/assets/91002836/d6737fbf-fb0c-407c-8b74-04d88262acf7)

