### PR TITLE
feature_41/validator:nameに関するバリデーション

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,10 +4,10 @@ name: Java CI with Gradle
 on:
   pull_request:
   push:
-    branches:
-      - main
+  #    branches:
+  #     - main
 
-      # アクション実行時にリポジトリのコンテンツに対する権限
+  # アクション実行時にリポジトリのコンテンツに対する権限
 permissions:
   contents: read
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,11 +22,14 @@ jobs:
     # 実行手順
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 17
+      - name: Set up JDK 17 and Gradle 8.1.1
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'adopt'
+      - name: Set up Gradle 8.1.1
+        run: gradle wrapper --gradle-version 8.1.1
+
 
       # MySQLサーバーをdocker composeで起動
       - name: Start MySQL Server
@@ -35,9 +38,11 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew test
 
-      #ユニットテスト結果をGitHubにアップロードする
+      # ユニットテスト結果をGitHubにアップロードする
+      # if: always()失敗した時も常に実行する
       - name: Archive unit test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
+        if: always()
         with:
           name: unit-test-report
           path: build/reports/tests/test

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,8 +4,8 @@ name: Java CI with Gradle
 on:
   pull_request:
   push:
-  #    branches:
-  #     - main
+    branches:
+      - main
 
   # アクション実行時にリポジトリのコンテンツに対する権限
 permissions:

--- a/NOTE/GithubActions.md
+++ b/NOTE/GithubActions.md
@@ -25,6 +25,7 @@
     - `uses`:ジョブで指定するリポジトリ
 - `run`:具体的なシェルで`|`を使えばパイプライン処理も可能
 - `run-name:`pushやpull_requestイベントによってトリガーされるワークフローの場合、コミットメッセージとして設定される
+- `if: always()`:Archive unit test resultsステップに記述することで、常に実行されるようになる
 
 ## タスク順序
 
@@ -32,7 +33,7 @@
 - pull Requestをトリガーとして動くようにワークフローを修正
 - Gradleでtestする方法を調べる
 - GitHub ActionsでGradleをzipに固めてアップロードする方法を検索
-- /gradle testの実行結果のテストレポートをUploadするようにワークフローを修正
+- /gradlew testの実行結果のテストレポートをUploadするようにワークフローを修正
 
 ## gradleでtestする方法
 
@@ -46,7 +47,7 @@
 
 ---
 
-- uses:actions/upload-artifact@v2:upload-artifactを使用してアップロードを行う
+- `uses:actions/upload-artifact@v2`:`upload-artifact`を使用してアップロードを行う
 - アップロード先:GitHubのストレージ
 
 ## artifact確認方法

--- a/NOTE/it-memo.md
+++ b/NOTE/it-memo.md
@@ -36,7 +36,7 @@
 
 リクエストボディを書く
 
-- `JSONAsserr.assertEquals`:JSON形式で新規登録する情報を全て記述する(SkiresortResponseのフィールドに合わせること)
+- `JSONAssert.assertEquals`:JSON形式で新規登録する情報を全て記述する(SkiresortResponseのフィールドに合わせること)
 
 ### 存在するIDを指定してスキーリゾート情報を更新する
 
@@ -54,8 +54,9 @@
 - dd:日(2文字)
 - T:T文字(日付と時刻を区別するための文字)
 - HH:時(2文字)
+- mm:分（2文字）
 - ss:秒(2文字)
-- sssssssss:ナノ秒(9文字)
+- SSSSSSSSS:ナノ秒(9文字)
 - XXX:タイムゾーンオフセット
 - 時差:日本はUTC(協定世界時)から+9
 - JST:日本標準時
@@ -66,7 +67,7 @@ timestampの比較:テスト実行のタイミングや実行速度がリアル�
 
 - LocalDateTime nowDate = LocalDateTime.now();特定のタイムゾーンに依存しない場合の現在時刻の取得
 - ZoneDataTime now = ZonedDateTime now();プログラムを実行した場所(国)での現在自刻の取得
-- "/skiresorts/{id}", 100":存在しないIDのパスOkを指定
+- "/skiresorts/{id}", 100":存在しないIDのパスを指定
 - assert.Equalsの内容
     - "path":期待する値のパス(100は存在しない)->"/skiresorts/100"
     - "status":期待するステータスコード
@@ -74,7 +75,7 @@ timestampの比較:テスト実行のタイミングや実行速度がリアル�
     - "timestamp":今回は適当。ISO 8601形式に従って記載
     - "error":ステータスコードに対応したエラー
 - `JSONCompareMode.STRICT`:JSON比較モードで全てのフィールドが一致していること
-- `((o1, o2) -> (true)`:object1,2は常にtrueを返す->timestampの値は比較除外される
+- `((o1, o2) -> true)`:object1(期待値),object2(実際の値)は常にtrueを返す->timestampの値は比較除外される
 
 ### IDを指定してスキーリゾートを削除する
 

--- a/NOTE/validation.md
+++ b/NOTE/validation.md
@@ -69,3 +69,34 @@
 ->postリクエストを送ると返ってくる(返ってくる＝失敗)<br>
 ->正しい場合:例外は出ない<br>
 ->ExceptionHandlerを通る場合またはControllerを通る場合に分かれる
+
+## Validator
+
+- SkiresortUpdateFormにバリデーション設定
+- `@Size`:1文字〜20文字
+- `@BeforeAll`:付与されたstaticメソッドは全テストが実行される前に実行されるメソッド
+- `import static org.assertj.core.api.Assertions.assertThat;`:手動で追加
+- `import jakarta.validation.ValidatorFactory;`手動で追加
+- `ValidatorFactory 変数 = Validation.buildDefaultValidatorFactory();`:バリデーションを扱うValidatorクラスを生成するファクトリークラス
+- `Validator 変数 = [ValidatorFactory] .getValidator();`:ValidatorFactoryからgetValidatorメソッドでValidatorクラスのインスタンスを取得する->
+  Validatorがバリデーションに関する各種の機能を提供してくれる
+- `var`:Java10以降で変数宣言で型推論を利用する(変数定義の際自動的に型決定される)->動的型付けではないため一度varで定義した変数に別の型の値を再代入することはできない
+- `@Size`デフォルトメッセージ:"{min} から {max} の間のサイズにしてください"(半角スペース有)
+- `.extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)`
+    - `extracting`:AssertJライブラリの一部で、リストやコレクションから特定の要素を抽出して検証する
+    - `violations`:リストの各要素に対して、ConstraintViolationオブジェクト(nameやarea)を文字列に変換し、ConstraintViolationオブジェクト(
+      バリデーションエラーが発生した際に生成されるオブジェクト)からエラーメッセージを取得する
+    - `containsExactlyInAnyOrder`:期待されるプロパティパス(バリデーションエラーが発生した場所)、エラーメッセージと実際の結果が一致することを検証する
+- Formフィールドのアノテーション:messageは全てのアノテーションに書くか書かないかを統一すること
+- STRICT:日付と時刻を厳密に解決する
+- LENIENT:日付と時刻を厳密ではない方法で解決する
+
+## Controller注意
+
+try catchで囲むことによって全てのExceptionをcatchしてしまう<br>
+バリデーション以外の全てのException(DB系のエラーなど)全てHTTPステータスコード400"1文字以上20文字以下で入力してください"というメッセージでレスポンスされてしまう
+
+## エラー対策
+
+- 期待値と違うエラー:デバッグしてresponseを確認する
+- 期待値が日本語、実際の値が英語のためアサーションエラー:テストコードに`Locale.setDefault(Locale.JAPANESE);`を書く

--- a/src/main/java/com/example/skiresortapi/controller/SkiresortController.java
+++ b/src/main/java/com/example/skiresortapi/controller/SkiresortController.java
@@ -42,12 +42,12 @@ public class SkiresortController {
     }
 
     @PostMapping("/skiresorts")
-    public ResponseEntity<SkiresortResponse> createSkiresort(@RequestBody @Valid SkiresortCreateForm skiresortCreateForm, UriComponentsBuilder uriBuilder) {
+    public ResponseEntity<?> createSkiresort(@RequestBody @Valid SkiresortCreateForm skiresortCreateForm, UriComponentsBuilder uriBuilder) {
         Skiresort skiresort = skiresortService.createSkiresort(skiresortCreateForm);
 
         // skiresortオブジェクトを元にレスポンス用のオブジェクトを生成
         SkiresortResponse skiresortResponse = new SkiresortResponse(skiresort);
-        // URI:リソースの位置や名前を特定するためのもの
+        // URI:リソースの位置や名前を特定する
         // HttpServletRequestのインスタンスでリクエストの中身を取得し、動的なURLを生成
         URI location = uriBuilder.path("/skiresorts/{id}").buildAndExpand(skiresort.getId()).toUri();
         return ResponseEntity.created(location).body(skiresortResponse);

--- a/src/main/java/com/example/skiresortapi/controller/form/SkiresortCreateForm.java
+++ b/src/main/java/com/example/skiresortapi/controller/form/SkiresortCreateForm.java
@@ -1,12 +1,19 @@
 package com.example.skiresortapi.controller.form;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public class SkiresortCreateForm {
+
+    @Size(min = 1, max = 20)
     @NotBlank
     private String name;
+
+    @Size(min = 1, max = 20)
     @NotBlank
     private String area;
+    
+    @Size(min = 1, max = 50)
     @NotBlank
     private String impression;
 

--- a/src/test/java/com/example/skiresortapi/integrationtest/SkiresortRestApiIntegrationTest.java
+++ b/src/test/java/com/example/skiresortapi/integrationtest/SkiresortRestApiIntegrationTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
@@ -82,7 +83,7 @@ public class SkiresortRestApiIntegrationTest {
         @DataSet(value = "datasets/it/skiresort.yml")
         @Transactional
         void 存在しないIDのスキーリゾートを取得した時ステータスコード404を返すこと() throws Exception {
-            mockMvc.perform(MockMvcRequestBuilders.get("/skiresorts{id}", 99))
+            mockMvc.perform(MockMvcRequestBuilders.get("/skiresorts/{id}", 99))
                     .andExpect(status().isNotFound());
         }
     }
@@ -91,6 +92,7 @@ public class SkiresortRestApiIntegrationTest {
     class CreateTest {
         @Test
         @DataSet(value = "datasets/it/skiresort.yml")
+        @ExpectedDataSet(value = "datasets/it/create-skiresort.yml", ignoreCols = {"id"})
         @Transactional
         void 新規のスキーリゾートを登録した時ステータスコード201を返すこと() throws Exception {
             String response = mockMvc.perform(MockMvcRequestBuilders.post("/skiresorts")
@@ -102,7 +104,7 @@ public class SkiresortRestApiIntegrationTest {
                                         "impression": "Obtained Canadian snowboard instructor license"
                                     }
                                     """))
-                    .andExpect(status().isCreated())
+                    .andExpect(MockMvcResultMatchers.status().isCreated())
                     .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
             JSONAssert.assertEquals("""
@@ -127,11 +129,11 @@ public class SkiresortRestApiIntegrationTest {
                                     {
                                         "id": 3,
                                         "name": "Treble Cone",
-                                        "area": "NewZealand",
+                                        "area": "New Zealand",
                                         "impression": "Features a long course with views of Lake Wanaka"
                                     }
                                     """))
-                    .andExpect(status().isOk())
+                    .andExpect(MockMvcResultMatchers.status().isOk())
                     .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
             JSONAssert.assertEquals("""
@@ -149,13 +151,12 @@ public class SkiresortRestApiIntegrationTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("""
                                     {
-                                        "id": 100,
                                         "name": "Blue Mountain",
                                         "area": "Canada",
                                         "impression": "All of the lodges and ski houses are cute, like a dreamland"
                                     }
                                     """))
-                    .andExpect(status().isNotFound())
+                    .andExpect(MockMvcResultMatchers.status().isNotFound())
                     .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
             JSONAssert.assertEquals("""
@@ -179,7 +180,7 @@ public class SkiresortRestApiIntegrationTest {
         @Transactional
         void 存在するIDを指定してスキーリゾートを削除した時ステータスコード200を返すこと() throws Exception {
             String response = mockMvc.perform(MockMvcRequestBuilders.delete("/skiresorts/{id}", 3))
-                    .andExpect(status().isOk())
+                    .andExpect(MockMvcResultMatchers.status().isOk())
                     .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
             JSONAssert.assertEquals("""
@@ -206,6 +207,7 @@ public class SkiresortRestApiIntegrationTest {
                         "error": "Not Found"
                     }
                                         
+                    // timestampは比較対象外                    
                     """, response, new CustomComparator(JSONCompareMode.STRICT, new Customization("timestamp", ((o1, o2) -> true))));
         }
     }

--- a/src/test/java/com/example/skiresortapi/integrationtest/SkiresortRestApiIntegrationTest.java
+++ b/src/test/java/com/example/skiresortapi/integrationtest/SkiresortRestApiIntegrationTest.java
@@ -28,30 +28,20 @@ public class SkiresortRestApiIntegrationTest {
     MockMvc mockMvc;
 
     @Nested
-    class ReadAllTest {
+    class ReadByIdTest {
         @Test
         @DataSet(value = "datasets/it/skiresort.yml")
         @Transactional
-        void スキーリゾートを全件取得した時ステータスコード200を返すこと() throws Exception {
-            String response = mockMvc.perform(MockMvcRequestBuilders.get("/skiresorts"))
+        void 存在するIDのスキーリゾートを取得した時ステータスコード200を返すこと() throws Exception {
+            String response = mockMvc.perform(MockMvcRequestBuilders.get("/skiresorts/{id}", 3))
                     .andExpect(status().isOk())
                     .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
             JSONAssert.assertEquals("""
-                    [
-                        {
-                            "name": "LakeLouise",
-                            "area": "Canada"
-                        },
-                        {
-                            "name": "Vail",
-                            "area": "Colorado"
-                        },
                         {
                             "name": "Zermatt",
                             "area": "Swiss"
                         }
-                    ]
                     """, response, JSONCompareMode.STRICT);
         }
     }

--- a/src/test/java/com/example/skiresortapi/integrationtest/SkiresortRestApiIntegrationTest.java
+++ b/src/test/java/com/example/skiresortapi/integrationtest/SkiresortRestApiIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.example.skiresortapi.integrationtest;
 
 import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -10,13 +11,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
-
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -28,29 +29,30 @@ public class SkiresortRestApiIntegrationTest {
     MockMvc mockMvc;
 
     @Nested
-    class ReadByIdTest {
+    class CreateTest {
         @Test
         @DataSet(value = "datasets/it/skiresort.yml")
+        @ExpectedDataSet(value = "datasets/it/create-skiresort.yml", ignoreCols = {"id"})
         @Transactional
-        void 存在するIDのスキーリゾートを取得した時ステータスコード200を返すこと() throws Exception {
-            String response = mockMvc.perform(MockMvcRequestBuilders.get("/skiresorts/{id}", 3))
-                    .andExpect(status().isOk())
+        void 新規のスキーリゾートを登録した時ステータスコード201を返すこと() throws Exception {
+            String response = mockMvc.perform(MockMvcRequestBuilders.post("/skiresorts")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "name": "Whistler",
+                                        "area": "Canada",
+                                        "impression": "Obtained Canadian snowboard instructor license"
+                                    }
+                                    """))
+                    .andExpect(MockMvcResultMatchers.status().isCreated())
                     .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
             JSONAssert.assertEquals("""
-                        {
-                            "name": "Zermatt",
-                            "area": "Swiss"
+                    {
+                        "name": "Whistler",
+                        "area": "Canada"
                         }
-                    """, response, JSONCompareMode.STRICT);
-        }
-
-        @Test
-        @DataSet(value = "datasets/it/skiresort.yml")
-        @Transactional
-        void 存在しないIDのスキーリゾートを取得した時ステータスコード404を返すこと() throws Exception {
-            mockMvc.perform(MockMvcRequestBuilders.get("/skiresorts/{id}", 99))
-                    .andExpect(status().isNotFound());
+                        """, response, JSONCompareMode.STRICT);
         }
     }
 }

--- a/src/test/java/com/example/skiresortapi/integrationtest/SkiresortRestApiIntegrationTest.java
+++ b/src/test/java/com/example/skiresortapi/integrationtest/SkiresortRestApiIntegrationTest.java
@@ -5,8 +5,10 @@ import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.Customization;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.skyscreamer.jsonassert.comparator.CustomComparator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -53,6 +55,34 @@ public class SkiresortRestApiIntegrationTest {
                         "message": "successfully update"
                     }
                     """, response, JSONCompareMode.STRICT);
+        }
+
+        @Test
+        @DataSet(value = "datasets/it/skiresort.yml")
+        @Transactional
+        void 存在しないIDのスキーリゾートを更新した時ステータスコード404を返すこと() throws Exception {
+            String response = mockMvc.perform(MockMvcRequestBuilders.patch("/skiresorts/{id}", 100)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "name": "Blue Mountain",
+                                        "area": "Canada",
+                                        "impression": "All of the lodges and ski houses are cute, like a dreamland"
+                                    }
+                                    """))
+                    .andExpect(MockMvcResultMatchers.status().isNotFound())
+                    .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+            JSONAssert.assertEquals("""
+                    {
+                        "path": "/skiresorts/100",
+                        "status": "404",
+                        "message": "resource not found",
+                        "timestamp": "2024-03-10T20:48.123456789+09:00[JST/Tokyo]",
+                        "error": "Not Found"
+                    }
+                    // timestampは比較対象外
+                    """, response, new CustomComparator(JSONCompareMode.STRICT, new Customization("timestamp", ((o1, o2) -> true))));
         }
     }
 }

--- a/src/test/java/com/example/skiresortapi/integrationtest/SkiresortRestApiIntegrationTest.java
+++ b/src/test/java/com/example/skiresortapi/integrationtest/SkiresortRestApiIntegrationTest.java
@@ -13,13 +13,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -31,28 +31,19 @@ public class SkiresortRestApiIntegrationTest {
     MockMvc mockMvc;
 
     @Nested
-    class UpdateTest {
+    class DeleteTest {
         @Test
         @DataSet(value = "datasets/it/skiresort.yml")
-        @ExpectedDataSet(value = "datasets/it/update-skiresort.yml")
+        @ExpectedDataSet(value = "datasets/it/delete-skiresort.yml")
         @Transactional
-        void 存在するIDを指定してスキーリゾート情報を更新するとステータスコード200を返すこと() throws Exception {
-            String response = mockMvc.perform(MockMvcRequestBuilders.patch("/skiresorts/{id}", 3)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("""
-                                    {
-                                        "id": 3,
-                                        "name": "Treble Cone",
-                                        "area": "New Zealand",
-                                        "impression": "Features a long course with views of Lake Wanaka"
-                                    }
-                                    """))
-                    .andExpect(MockMvcResultMatchers.status().isOk())
+        void 存在するIDを指定してスキーリゾートを削除した時ステータスコード200を返すこと() throws Exception {
+            String response = mockMvc.perform(MockMvcRequestBuilders.delete("/skiresorts/{id}", 3))
+                    .andExpect(status().isOk())
                     .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
             JSONAssert.assertEquals("""
                     {
-                        "message": "successfully update"
+                        "message": "successfully deleted"
                     }
                     """, response, JSONCompareMode.STRICT);
         }
@@ -60,28 +51,21 @@ public class SkiresortRestApiIntegrationTest {
         @Test
         @DataSet(value = "datasets/it/skiresort.yml")
         @Transactional
-        void 存在しないIDのスキーリゾートを更新した時ステータスコード404を返すこと() throws Exception {
-            String response = mockMvc.perform(MockMvcRequestBuilders.patch("/skiresorts/{id}", 100)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("""
-                                    {
-                                        "name": "Blue Mountain",
-                                        "area": "Canada",
-                                        "impression": "All of the lodges and ski houses are cute, like a dreamland"
-                                    }
-                                    """))
-                    .andExpect(MockMvcResultMatchers.status().isNotFound())
+        void 存在しないIDのスキーリゾートを削除した時ステータスコード404を返すこと() throws Exception {
+            String response = mockMvc.perform(MockMvcRequestBuilders.delete("/skiresorts/{id}", 5))
+                    .andExpect(status().isNotFound())
                     .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
             JSONAssert.assertEquals("""
                     {
-                        "path": "/skiresorts/100",
+                        "path": "/skiresorts/5",
                         "status": "404",
                         "message": "resource not found",
-                        "timestamp": "2024-03-10T20:48.123456789+09:00[JST/Tokyo]",
+                        "timestamp": "2024-03-10T22:00:00:123456789+09:00[JST/Tokyo]",
                         "error": "Not Found"
                     }
-                    // timestampは比較対象外
+                                        
+                    // timestampは比較対象外                    
                     """, response, new CustomComparator(JSONCompareMode.STRICT, new Customization("timestamp", ((o1, o2) -> true))));
         }
     }

--- a/src/test/java/com/example/skiresortapi/integrationtest/SkiresortRestApiIntegrationTest.java
+++ b/src/test/java/com/example/skiresortapi/integrationtest/SkiresortRestApiIntegrationTest.java
@@ -29,30 +29,30 @@ public class SkiresortRestApiIntegrationTest {
     MockMvc mockMvc;
 
     @Nested
-    class CreateTest {
+    class UpdateTest {
         @Test
         @DataSet(value = "datasets/it/skiresort.yml")
-        @ExpectedDataSet(value = "datasets/it/create-skiresort.yml", ignoreCols = {"id"})
+        @ExpectedDataSet(value = "datasets/it/update-skiresort.yml")
         @Transactional
-        void 新規のスキーリゾートを登録した時ステータスコード201を返すこと() throws Exception {
-            String response = mockMvc.perform(MockMvcRequestBuilders.post("/skiresorts")
+        void 存在するIDを指定してスキーリゾート情報を更新するとステータスコード200を返すこと() throws Exception {
+            String response = mockMvc.perform(MockMvcRequestBuilders.patch("/skiresorts/{id}", 3)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("""
                                     {
-                                        "name": "Whistler",
-                                        "area": "Canada",
-                                        "impression": "Obtained Canadian snowboard instructor license"
+                                        "id": 3,
+                                        "name": "Treble Cone",
+                                        "area": "New Zealand",
+                                        "impression": "Features a long course with views of Lake Wanaka"
                                     }
                                     """))
-                    .andExpect(MockMvcResultMatchers.status().isCreated())
+                    .andExpect(MockMvcResultMatchers.status().isOk())
                     .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
             JSONAssert.assertEquals("""
                     {
-                        "name": "Whistler",
-                        "area": "Canada"
-                        }
-                        """, response, JSONCompareMode.STRICT);
+                        "message": "successfully update"
+                    }
+                    """, response, JSONCompareMode.STRICT);
         }
     }
 }

--- a/src/test/java/com/example/skiresortapi/integrationtest/SkiresortRestApiIntegrationTest.java
+++ b/src/test/java/com/example/skiresortapi/integrationtest/SkiresortRestApiIntegrationTest.java
@@ -1,22 +1,17 @@
 package com.example.skiresortapi.integrationtest;
 
 import com.github.database.rider.core.api.dataset.DataSet;
-import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.skyscreamer.jsonassert.Customization;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
-import org.skyscreamer.jsonassert.comparator.CustomComparator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
@@ -58,157 +53,6 @@ public class SkiresortRestApiIntegrationTest {
                         }
                     ]
                     """, response, JSONCompareMode.STRICT);
-        }
-    }
-
-    @Nested
-    class ReadByIdTest {
-        @Test
-        @DataSet(value = "datasets/it/skiresort.yml")
-        @Transactional
-        void 存在するIDのスキーリゾートを取得した時ステータスコード200を返すこと() throws Exception {
-            String response = mockMvc.perform(MockMvcRequestBuilders.get("/skiresorts/{id}", 3))
-                    .andExpect(status().isOk())
-                    .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
-
-            JSONAssert.assertEquals("""
-                        {
-                            "name": "Zermatt",
-                            "area": "Swiss"
-                        }
-                    """, response, JSONCompareMode.STRICT);
-        }
-
-        @Test
-        @DataSet(value = "datasets/it/skiresort.yml")
-        @Transactional
-        void 存在しないIDのスキーリゾートを取得した時ステータスコード404を返すこと() throws Exception {
-            mockMvc.perform(MockMvcRequestBuilders.get("/skiresorts/{id}", 99))
-                    .andExpect(status().isNotFound());
-        }
-    }
-
-    @Nested
-    class CreateTest {
-        @Test
-        @DataSet(value = "datasets/it/skiresort.yml")
-        @ExpectedDataSet(value = "datasets/it/create-skiresort.yml", ignoreCols = {"id"})
-        @Transactional
-        void 新規のスキーリゾートを登録した時ステータスコード201を返すこと() throws Exception {
-            String response = mockMvc.perform(MockMvcRequestBuilders.post("/skiresorts")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("""
-                                    {
-                                        "name": "Whistler",
-                                        "area": "Canada",
-                                        "impression": "Obtained Canadian snowboard instructor license"
-                                    }
-                                    """))
-                    .andExpect(MockMvcResultMatchers.status().isCreated())
-                    .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
-
-            JSONAssert.assertEquals("""
-                    {
-                        "name": "Whistler",
-                        "area": "Canada"
-                        }
-                        """, response, JSONCompareMode.STRICT);
-        }
-    }
-
-    @Nested
-    class UpdateTest {
-        @Test
-        @DataSet(value = "datasets/it/skiresort.yml")
-        @ExpectedDataSet(value = "datasets/it/update-skiresort.yml")
-        @Transactional
-        void 存在するIDを指定してスキーリゾート情報を更新するとステータスコード200を返すこと() throws Exception {
-            String response = mockMvc.perform(MockMvcRequestBuilders.patch("/skiresorts/{id}", 3)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("""
-                                    {
-                                        "id": 3,
-                                        "name": "Treble Cone",
-                                        "area": "New Zealand",
-                                        "impression": "Features a long course with views of Lake Wanaka"
-                                    }
-                                    """))
-                    .andExpect(MockMvcResultMatchers.status().isOk())
-                    .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
-
-            JSONAssert.assertEquals("""
-                    {
-                        "message": "successfully update"
-                    }
-                    """, response, JSONCompareMode.STRICT);
-        }
-
-        @Test
-        @DataSet(value = "datasets/it/skiresort.yml")
-        @Transactional
-        void 存在しないIDのスキーリゾートを更新した時ステータスコード404を返すこと() throws Exception {
-            String response = mockMvc.perform(MockMvcRequestBuilders.patch("/skiresorts/{id}", 100)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("""
-                                    {
-                                        "name": "Blue Mountain",
-                                        "area": "Canada",
-                                        "impression": "All of the lodges and ski houses are cute, like a dreamland"
-                                    }
-                                    """))
-                    .andExpect(MockMvcResultMatchers.status().isNotFound())
-                    .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
-
-            JSONAssert.assertEquals("""
-                    {
-                        "path": "/skiresorts/100",
-                        "status": "404",
-                        "message": "resource not found",
-                        "timestamp": "2024-03-10T20:48.123456789+09:00[JST/Tokyo]",
-                        "error": "Not Found"
-                    }
-                    // timestampは比較対象外
-                    """, response, new CustomComparator(JSONCompareMode.STRICT, new Customization("timestamp", ((o1, o2) -> true))));
-        }
-    }
-
-    @Nested
-    class DeleteTest {
-        @Test
-        @DataSet(value = "datasets/it/skiresort.yml")
-        @ExpectedDataSet(value = "datasets/it/delete-skiresort.yml")
-        @Transactional
-        void 存在するIDを指定してスキーリゾートを削除した時ステータスコード200を返すこと() throws Exception {
-            String response = mockMvc.perform(MockMvcRequestBuilders.delete("/skiresorts/{id}", 3))
-                    .andExpect(MockMvcResultMatchers.status().isOk())
-                    .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
-
-            JSONAssert.assertEquals("""
-                    {
-                        "message": "successfully deleted"
-                    }
-                    """, response, JSONCompareMode.STRICT);
-        }
-
-        @Test
-        @DataSet(value = "datasets/it/skiresort.yml")
-        @Transactional
-        void 存在しないIDのスキーリゾートを削除した時ステータスコード404を返すこと() throws Exception {
-            String response = mockMvc.perform(MockMvcRequestBuilders.delete("/skiresorts/{id}", 5))
-                    .andExpect(status().isNotFound())
-                    .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
-
-            JSONAssert.assertEquals("""
-                    {
-                        "path": "/skiresorts/5",
-                        "status": "404",
-                        "message": "resource not found",
-                        "timestamp": "2024-03-10T22:00:00:123456789+09:00[JST/Tokyo]",
-                        "error": "Not Found"
-                    }
-                                        
-                    // timestampは比較対象外                    
-                    """, response, new CustomComparator(JSONCompareMode.STRICT, new Customization("timestamp", ((o1, o2) -> true))));
         }
     }
 }

--- a/src/test/java/com/example/skiresortapi/integrationtest/SkiresortRestApiIntegrationTest.java
+++ b/src/test/java/com/example/skiresortapi/integrationtest/SkiresortRestApiIntegrationTest.java
@@ -28,20 +28,30 @@ public class SkiresortRestApiIntegrationTest {
     MockMvc mockMvc;
 
     @Nested
-    class ReadByIdTest {
+    class ReadAllTest {
         @Test
         @DataSet(value = "datasets/it/skiresort.yml")
         @Transactional
-        void 存在するIDのスキーリゾートを取得した時ステータスコード200を返すこと() throws Exception {
-            String response = mockMvc.perform(MockMvcRequestBuilders.get("/skiresorts/{id}", 3))
+        void スキーリゾートを全件取得した時ステータスコード200を返すこと() throws Exception {
+            String response = mockMvc.perform(MockMvcRequestBuilders.get("/skiresorts"))
                     .andExpect(status().isOk())
                     .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
             JSONAssert.assertEquals("""
+                    [
+                        {
+                            "name": "LakeLouise",
+                            "area": "Canada"
+                        },
+                        {
+                            "name": "Vail",
+                            "area": "Colorado"
+                        },
                         {
                             "name": "Zermatt",
                             "area": "Swiss"
                         }
+                    ]
                     """, response, JSONCompareMode.STRICT);
         }
     }

--- a/src/test/java/com/example/skiresortapi/integrationtest/SkiresortRestApiIntegrationTest.java
+++ b/src/test/java/com/example/skiresortapi/integrationtest/SkiresortRestApiIntegrationTest.java
@@ -28,31 +28,29 @@ public class SkiresortRestApiIntegrationTest {
     MockMvc mockMvc;
 
     @Nested
-    class ReadAllTest {
+    class ReadByIdTest {
         @Test
         @DataSet(value = "datasets/it/skiresort.yml")
         @Transactional
-        void スキーリゾートを全件取得した時ステータスコード200を返すこと() throws Exception {
-            String response = mockMvc.perform(MockMvcRequestBuilders.get("/skiresorts"))
+        void 存在するIDのスキーリゾートを取得した時ステータスコード200を返すこと() throws Exception {
+            String response = mockMvc.perform(MockMvcRequestBuilders.get("/skiresorts/{id}", 3))
                     .andExpect(status().isOk())
                     .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
             JSONAssert.assertEquals("""
-                    [
-                        {
-                            "name": "LakeLouise",
-                            "area": "Canada"
-                        },
-                        {
-                            "name": "Vail",
-                            "area": "Colorado"
-                        },
                         {
                             "name": "Zermatt",
                             "area": "Swiss"
                         }
-                    ]
                     """, response, JSONCompareMode.STRICT);
+        }
+
+        @Test
+        @DataSet(value = "datasets/it/skiresort.yml")
+        @Transactional
+        void 存在しないIDのスキーリゾートを取得した時ステータスコード404を返すこと() throws Exception {
+            mockMvc.perform(MockMvcRequestBuilders.get("/skiresorts/{id}", 99))
+                    .andExpect(status().isNotFound());
         }
     }
 }

--- a/src/test/java/com/example/skiresortapi/validation/SkiresortCreateFormTest.java
+++ b/src/test/java/com/example/skiresortapi/validation/SkiresortCreateFormTest.java
@@ -1,0 +1,71 @@
+package com.example.skiresortapi.validation;
+
+import com.example.skiresortapi.controller.form.SkiresortCreateForm;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+
+public class SkiresortCreateFormTest {
+
+    private static Validator validator;
+
+    // 一番最初に一度だけ実行される
+    @BeforeAll
+    public static void setUpValidator() {
+        Locale.setDefault(Locale.JAPANESE);
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Nested
+    class NameTest {
+        @Test
+        public void nameが1文字未満である時バリデーションエラーとなること() {
+
+            SkiresortCreateForm createForm = new SkiresortCreateForm("", "Canada", "The scenery was very beautiful");
+            var violations = validator.validate(createForm);
+            // バリデーションが2つ発生することの検証
+            assertThat(violations).hasSize(2);
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(
+                            tuple("name", "空白は許可されていません"),
+                            tuple("name", "1 から 20 の間のサイズにしてください")
+                    );
+        }
+
+        @Test
+        public void nameが1文字である時バリデーションエラーとならないこと() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("a", "Canada", "The scenery was very beautiful");
+            var violations = validator.validate(createForm);
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        public void nameが20文字である時バリデーションエラーとならないこと() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("aaaaaaaaaaaaaaaaaaaa", "Canada", "The scenery was very beautiful");
+            var violations = validator.validate(createForm);
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        public void nameが21文字である時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("aaaaaaaaaaaaaaaaaaaaa", "Canada", "The scenery was very beautiful");
+            var violations = validator.validate(createForm);
+            // バリデーションエラーが1つ発生することの検証
+            assertThat(violations).hasSize(1);
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(tuple("name", "1 から 20 の間のサイズにしてください"));
+        }
+    }
+}

--- a/src/test/resources/datasets/it/update-skiresort.yml
+++ b/src/test/resources/datasets/it/update-skiresort.yml
@@ -12,5 +12,5 @@ skiresort:
 
   - id: 3
     name: "Treble Cone"
-    area: "NewZealand"
+    area: "New Zealand"
     impression: "Features a long course with views of Lake Wanaka"


### PR DESCRIPTION
# SkiresortCreateFormTest:nameに関するバリデーションを実装

## バリデーション内容
- `@Size`(min = 1, max = 20):1文字以上20文字以下であること
- `@NotBlank`:null/空文字/スペースは許可していないこと

## 実装テストケース
- nameが1文字未満である時バリデーションエラーとなること
- nameが1文字である時バリデーションエラーとならないこと
- nameが20文字である時バリデーションエラーとならないこと
- nameが21文字である時バリデーションエラーとなること
- nameが半角ブランクである時バリデーションエラーとなること
- nameがnullである時バリデーションエラーとなること
- nameが全角ブランクである時バリデーションエラーとならないこと

## 動作確認ポイント
- 境界値1、20文字に対するバリデーションを実施されていること
- GitHub Actionsでテストレポートが自動生成されていること

## 苦労したこと
1.  テストがローカルで成功しているのにGitHub Actionsで期待値が日本語、実際の値が英語というエラー表示された
2. テストがローカルで成功、テストレポートも100%成功しているのに、GitHub Actionsでエラー表示

### 現象
1. GitHub Actionsのサーバーのロケールがen_USになっているためHibernate Validatorが英語のメッセージを返している
2. SkiresortRestApiIntegrationTestの存在するIDを指定してスキーリゾート情報を更新するとステータスコード200を返すことのテストでエラーだとエラーログに表示している

### エラー対応方法
1. 
- SkiresortCreateForm:フィールドのアノテーションmesssageを書くか書かないかで統一する(今回は書かない)
- SkiresortCreateFormTest:Localで日本語設定の記述をする
2. 
- 切り分けのため、SkiresortRestApiIntegrationTestのテストケースを1つずつpushしたがローカル、GitHub Actions共にエラー出ず
- 最終的にSkiresortRestApiIntegrationTestをまとめてpushしたところ、全てのエラーが解消していた(原因不明)

## 動作確認キャプチャ
![22D4C9A4-E3C6-4275-B699-AF568D16D864_1_201_a](https://github.com/yoko-newDeveloper/skiresortapi/assets/91002836/51a25d40-cad0-4cd3-b362-e00cf232afe4)
