### PR TITLE
feature_45/areaValidation:areaに関するテスト

### DIFF
--- a/NOTE/validation.md
+++ b/NOTE/validation.md
@@ -84,7 +84,8 @@
 - `@Size`デフォルトメッセージ:"{min} から {max} の間のサイズにしてください"(半角スペース有)
 - `.extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)`
     - `extracting`:AssertJライブラリの一部で、リストやコレクションから特定の要素を抽出して検証する
-    - `violations`:リストの各要素に対して、ConstraintViolationオブジェクト(nameやarea)を文字列に変換し、ConstraintViolationオブジェクト(
+    - `violations`(検証エラーのリスト):リストの各要素に対して、ConstraintViolationオブジェクト(nameやarea)
+      を文字列に変換し、ConstraintViolationオブジェクト(
       バリデーションエラーが発生した際に生成されるオブジェクト)からエラーメッセージを取得する
     - `containsExactlyInAnyOrder`:期待されるプロパティパス(バリデーションエラーが発生した場所)、エラーメッセージと実際の結果が一致することを検証する
 - Formフィールドのアノテーション:messageは全てのアノテーションに書くか書かないかを統一すること

--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ GitHub Actionsでワークフローを自動化する
 
 - ReadByIdメソッドのテストを追加
 
+## ブランチ:feature_45/areaValidation
+
+- areaに関するバリデーション
+
 ## 実装順理由
 
 | 順番 | 機能                 | 理由                                                  |

--- a/src/test/java/com/example/skiresortapi/integrationtest/SkiresortRestApiIntegrationTest.java
+++ b/src/test/java/com/example/skiresortapi/integrationtest/SkiresortRestApiIntegrationTest.java
@@ -34,6 +34,7 @@ public class SkiresortRestApiIntegrationTest {
 
     @Nested
     class ReadAllTest {
+
         @Test
         @DataSet(value = "datasets/it/skiresort.yml")
         @Transactional
@@ -63,6 +64,7 @@ public class SkiresortRestApiIntegrationTest {
 
     @Nested
     class ReadByIdTest {
+
         @Test
         @DataSet(value = "datasets/it/skiresort.yml")
         @Transactional
@@ -90,6 +92,7 @@ public class SkiresortRestApiIntegrationTest {
 
     @Nested
     class CreateTest {
+
         @Test
         @DataSet(value = "datasets/it/skiresort.yml")
         @ExpectedDataSet(value = "datasets/it/create-skiresort.yml", ignoreCols = {"id"})
@@ -118,6 +121,7 @@ public class SkiresortRestApiIntegrationTest {
 
     @Nested
     class UpdateTest {
+
         @Test
         @DataSet(value = "datasets/it/skiresort.yml")
         @ExpectedDataSet(value = "datasets/it/update-skiresort.yml")
@@ -174,6 +178,7 @@ public class SkiresortRestApiIntegrationTest {
 
     @Nested
     class DeleteTest {
+
         @Test
         @DataSet(value = "datasets/it/skiresort.yml")
         @ExpectedDataSet(value = "datasets/it/delete-skiresort.yml")

--- a/src/test/java/com/example/skiresortapi/mapper/SkiresortMapperTest.java
+++ b/src/test/java/com/example/skiresortapi/mapper/SkiresortMapperTest.java
@@ -25,6 +25,7 @@ class SkiresortMapperTest {
 
     @Nested
     class FindAllTest {
+
         @Test
         @DataSet(value = "datasets/ut/skiresort.yml")
         @Transactional
@@ -50,6 +51,7 @@ class SkiresortMapperTest {
 
     @Nested
     class FindByIdTest {
+
         @Test
         @DataSet(value = "datasets/ut/skiresort.yml")
         @Transactional
@@ -69,6 +71,7 @@ class SkiresortMapperTest {
 
     @Nested
     class CreateSkiresortTest {
+
         @Test
         @DataSet(value = "datasets/ut/skiresort.yml")
         @Transactional
@@ -80,6 +83,7 @@ class SkiresortMapperTest {
 
     @Nested
     class UpdateSkiresortTest {
+
         @Test
         @DataSet(value = "datasets/ut/skiresort.yml")
         @ExpectedDataSet(value = "datasets/ut/update-skiresort.yml")
@@ -101,6 +105,7 @@ class SkiresortMapperTest {
 
     @Nested
     class DeleteSkiresortTest {
+
         @Test
         @DataSet(value = "datasets/ut/skiresort.yml")
         @ExpectedDataSet(value = "datasets/ut/delete-skiresort.yml")

--- a/src/test/java/com/example/skiresortapi/service/SkiresortServiceImplTest.java
+++ b/src/test/java/com/example/skiresortapi/service/SkiresortServiceImplTest.java
@@ -32,6 +32,7 @@ class SkiresortServiceImplTest {
 
     @Nested
     class FindAllTest {
+
         @Test
         public void 全てのスキーリゾート情報を取得できること() {
 
@@ -54,6 +55,7 @@ class SkiresortServiceImplTest {
 
     @Nested // JUnit5におけるネストしたテスト
     class FindByIdTest { // テスト対象メソッド名でクラスを作成
+
         @Test
         public void 存在するスキーリゾートのIDを指定した時に正常データが返されること() {
             // doReturn -when :Mokietoの記述
@@ -82,6 +84,7 @@ class SkiresortServiceImplTest {
 
     @Nested
     class InsertSkiresortTest {
+
         @Test
         public void 新規のスキーリゾート情報を登録できること() {
             // skiresortCreateForm変数をインスタンス化して、それぞれの属性に値を設定
@@ -102,6 +105,7 @@ class SkiresortServiceImplTest {
 
     @Nested
     class UpdateSkiresortTest {
+
         @Test
         public void 指定したIDのスキーリゾート情報を更新できること() {
             // モック化:returnするSkiresortは更新前のデータを設定
@@ -136,6 +140,7 @@ class SkiresortServiceImplTest {
 
     @Nested
     class DeleteSkiresortTest {
+        
         @Test
         public void 指定したIDのスキーリゾート情報を削除できること() {
             doReturn(Optional.of(new Skiresort(1, "白馬乗鞍", "長野県", "初めてペンションに居候として山籠りし、初めて草大会に出場した思い出のゲレンデ"))).when(skiresortMapper).findById(1);

--- a/src/test/java/com/example/skiresortapi/validation/SkiresortCreateFormTest.java
+++ b/src/test/java/com/example/skiresortapi/validation/SkiresortCreateFormTest.java
@@ -14,7 +14,7 @@ import java.util.Locale;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 
-public class SkiresortCreateFormTest {
+class SkiresortCreateFormTest {
 
     private static Validator validator;
 
@@ -27,7 +27,8 @@ public class SkiresortCreateFormTest {
     }
 
     @Nested
-    class NameTest {
+    class NameSizeTest {
+
         @Test
         public void nameが1文字未満である時バリデーションエラーとなること() {
 
@@ -66,6 +67,113 @@ public class SkiresortCreateFormTest {
             assertThat(violations)
                     .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
                     .containsExactlyInAnyOrder(tuple("name", "1 から 20 の間のサイズにしてください"));
+        }
+    }
+
+    @Nested
+    class NameNotBlankTest {
+
+        @Test
+        public void nameが半角ブランクである時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm(" ", "Canada", "The scenery was very beautiful");
+            var violations = validator.validate(createForm);
+            assertThat(violations).hasSize(1);
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(tuple("name", "空白は許可されていません"));
+        }
+
+        @Test
+        public void nameがnullである時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm(null, "Canada", "The scenery was very beautiful");
+            var violations = validator.validate(createForm);
+            assertThat(violations).hasSize(1);
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(tuple("name", "空白は許可されていません"));
+        }
+
+        @Test
+        public void nameが全角ブランクである時バリデーションエラーとならないこと() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("　", "Canada", "The scenery was very beautiful");
+            var violations = validator.validate(createForm);
+            assertThat(violations).isEmpty();
+        }
+    }
+
+    @Nested
+    class AreaSizeTest {
+
+        @Test
+        public void areaが1文字未満である時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Remarkables", "", "Easy to slip even for beginners");
+            var violations = validator.validate(createForm);
+            assertThat(violations).hasSize(2);
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    // 特定の条件が順不要で一致することの検証
+                    .containsExactlyInAnyOrder(
+                            tuple("area", "空白は許可されていません"),
+                            tuple("area", "1 から 20 の間のサイズにしてください")
+                    );
+        }
+
+        @Test
+        public void areaが1文字である時バリデーションエラーとならないこと() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Remarkables", "a", "Easy to slip even for beginners");
+            var violations = validator.validate(createForm);
+            // エラーなしであることの検証
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        public void areaが20文字である時バリデーションエラーとならないこと() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Remarkables", "12345678901234567890", "Easy to slip even for beginners");
+            var violations = validator.validate(createForm);
+            // エラーなしであることの検証
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        public void areaが21文字である時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Remarkable", "123456789012345678901", "Easy to slip even for beginners");
+            var violations = validator.validate(createForm);
+            assertThat(violations).hasSize(1)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(
+                            tuple("area", "1 から 20 の間のサイズにしてください")
+                    );
+        }
+    }
+
+    @Nested
+    class AreaNotBlankTest {
+
+        @Test
+        public void areaが半角ブランクである時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Remarkable", " ", "Easy to slip even for beginners");
+            var violations = validator.validate(createForm);
+            assertThat(violations).hasSize(1);
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(tuple("area", "空白は許可されていません"));
+        }
+
+        @Test
+        public void areaがnullである時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Remarkable", null, "Easy to slip even for beginners");
+            var violations = validator.validate(createForm);
+            assertThat(violations).hasSize(1);
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(tuple("area", "空白は許可されていません"));
+        }
+
+        @Test
+        public void areaが全角ブランクである時バリデーションエラーとならないこと() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Remarkable", "　", "Easy to slip even for beginners");
+            var violations = validator.validate(createForm);
+            assertThat(violations).isEmpty();
         }
     }
 }


### PR DESCRIPTION
# areaの境界値に対するバリデーションの実装

## バリデーション内容
- '@Size`(min = 1, max = 20):1文字以上20文字以下であること
- '@NotBlank`:null/空文字/スペースは許可していないこと

## 実装テストケース
- areaが1文字未満である時バリデーションエラーとなること
- areaが1文字である時バリデーションエラーとならないこと
- areaが20文字である時バリデーションエラーとならないこと
- areaが21文字である時バリデーションエラーとなること
- areaが半角ブランクである時バリデーションエラーとなること
- areaがnullである時バリデーションエラーとなること
- areaが全角ブランクである時バリデーションエラーとならないこと

## 動作確認ポイント
- 境界値1、20文字に対するバリデーションを実施されていること
- GitHub Actionsでテストレポートが自動生成されていること

## 動作確認キャプチャ

![F454C589-D167-4C75-B2E2-A77B3FA413C5_1_201_a](https://github.com/yoko-newDeveloper/skiresortapi/assets/91002836/84ca1aaa-d0b5-4b40-81bc-679006ab3e04)
