### PR TITLE
feature_47/imperssionValidation:impressionに関するバリデーション

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ GitHub Actionsでワークフローを自動化する
 
 - areaに関するバリデーション
 
+## ブランチ:feature_47/imperssionValidation
+
+- impressionに関するバリデーション
+
 ## 実装順理由
 
 | 順番 | 機能                 | 理由                                                  |

--- a/src/test/java/com/example/skiresortapi/validation/SkiresortCreateFormTest.java
+++ b/src/test/java/com/example/skiresortapi/validation/SkiresortCreateFormTest.java
@@ -176,4 +176,74 @@ class SkiresortCreateFormTest {
             assertThat(violations).isEmpty();
         }
     }
+
+    @Nested
+    class ImpressionSizeTest {
+
+        @Test
+        public void impressionが1文字未満である時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Mt.Hoot", "USA", "");
+            var violations = validator.validate(createForm);
+            assertThat(violations).hasSize(2);
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(
+                            tuple("impression", "空白は許可されていません"),
+                            tuple("impression", "1 から 50 の間のサイズにしてください")
+                    );
+        }
+
+        @Test
+        public void impressionが1文字である時バリデーションエラーとならないこと() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Mt.Hoot", "USA", "1");
+            var violations = validator.validate(createForm);
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        public void impressionが50文字である時バリデーションエラーとならないとこ() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Mt.Hoot", "USA", "12345678901234567890123456789012345678901234567890");
+            var violations = validator.validate(createForm);
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        public void impressionが51文字である時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Mt.Hoot", "USA", "123456789012345678901234567890123456789012345678901");
+            var violations = validator.validate(createForm);
+            assertThat(violations).hasSize(1);
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(tuple("impression", "1 から 50 の間のサイズにしてください"));
+        }
+    }
+
+    @Nested
+    class ImpressionNotBlankTest {
+
+        @Test
+        public void impresstionが半角ブランクである時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Mt.Hoot", "USA", " ");
+            var violations = validator.validate(createForm);
+            assertThat(violations).hasSize(1)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(tuple("impression", "空白は許可されていません"));
+        }
+
+        @Test
+        public void impressionがnullである時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Mt.Hoot", "USA", null);
+            var violations = validator.validate(createForm);
+            assertThat(violations).hasSize(1)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(tuple("impression", "空白は許可されていません"));
+        }
+
+        @Test
+        public void impressionが全角ブランクである時バリデーションエラーとならないこと() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Mt.Hoot", "USA", "　");
+            var violations = validator.validate(createForm);
+            assertThat(violations).isEmpty();
+        }
+    }
 }

--- a/src/test/java/com/example/skiresortapi/validation/SkiresortCreateFormTest.java
+++ b/src/test/java/com/example/skiresortapi/validation/SkiresortCreateFormTest.java
@@ -201,7 +201,7 @@ class SkiresortCreateFormTest {
         }
 
         @Test
-        public void impressionが50文字である時バリデーションエラーとならないとこ() {
+        public void impressionが50文字である時バリデーションエラーとならないこと() {
             SkiresortCreateForm createForm = new SkiresortCreateForm("Mt.Hoot", "USA", "12345678901234567890123456789012345678901234567890");
             var violations = validator.validate(createForm);
             assertThat(violations).isEmpty();


### PR DESCRIPTION
# impressionに関するバリデーションを実装

## バリデーション内容
- `@Size`(min = 1, max = 50):1文字以上50文字以下であること
- `@NotBlank`:null/空文字/スペースは許可していないこと

## 実装テストケース
- impressionが1文字未満である時バリデーションエラーとなること
- impressionが1文字である時バリデーションエラーとならないこと
- impressionが50文字である時バリデーションエラーとならないこと
- impressionが51文字である時バリデーションエラーとなること
- impresstionが半角ブランクである時バリデーションエラーとなること
- impressionがnullである時バリデーションエラーとなること
- impressionが全角ブランクである時バリデーションエラーとならないこと

動作確認ポイント
- 境界値1、50文字に対するバリデーションを実施されていること
- GitHub Actionsでテストレポートが自動生成されていること

動作確認キャプチャ

![39DE215E-CD1B-4D80-8479-7A541DC8B5A9_1_201_a](https://github.com/yoko-newDeveloper/skiresortapi/assets/91002836/a698e57f-3b83-4fb9-9056-e6fde6084af0)
