### PR TITLE
Feature 51/correlation required validation:相関項目チェック

### DIFF
--- a/NOTE/correlationRequiredValidationPattern.md
+++ b/NOTE/correlationRequiredValidationPattern.md
@@ -1,0 +1,74 @@
+# バリデーションパターンを整理する
+
+### 全てのテストパターン
+
+NGパターン
+
+|   value    |  NG  | NG | NG  | 
+|:----------:|:----:|:--:|:---:|
+|    name    | null | "" | " " | 
+|    area    | null | "" | " " |
+| impression | null | "" | " " | 
+
+- nameOKパターン
+
+|   value    |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |
+|:----------:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|
+|    name    | hoge | hoge | hoge | hoge | hoge | hoge | hoge | hoge | hoge | hoge | hoge | hoge | hoge | hoge | hoge |
+|    area    | null | huge | huge |  ""  | huge |  ""  | " "  | huge | " "  | null |  ""  | null | " "  |  ""  | " "  |
+| impression | null | null | piyo |  ""  |  ""  | piyo | " "  | " "  | piyo |  ""  | null | " "  | null | " "  |  ""  |
+
+- areaOKパターン
+
+|   value    |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  | OK | OK |
+|:----------:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:--:|:--:|
+|    name    | null | null |  ""  |  ""  | " "  | " "  | null |  ""  | null | " "  |  ""  | " "  |      |    |    |
+|    area    | huga | huga | huga | huga | huga | huga | huga | huga | huga | huga | huga | huga | huga |
+| impression | null | piyo |  ""  | piyo | " "  | piyo |  ""  | null | " "  | null | " "  |  ""  |
+
+- impressionOKパターン
+
+|   value    |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |
+|:----------:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|
+|    name    | null |  ""  | " "  | null |  ""  | " "  | null |  ""  | " "  |
+|    area    | null |  ""  | " "  |  ""  | null | null | " "  | " "  |  ""  |
+| impression | piyo | piyo | piyo | piyo | piyo | piyo | piyo | piyo | piyo |
+
+### 実装パターン
+
+|   value    |  NG  | NG | NG  |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |  OK  |
+|:----------:|:----:|:--:|:---:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|
+|    name    | null | "" | " " | hoge | hoge |  ""  | hoge | hoge | " "  | hoge | hoge | hoge | hoge |  ""  |
+|    area    | null | "" | " " | null | huga | huga |  ""  | huga | huga | " "  | huga | null | huga | " "  |
+| impression | null | "" | " " | piyo | null | piyo | piyo |  ""  | piyo | piyo | " "  |  ""  | " "  | piyo |
+
+- 論理演算子：||（論理和）
+    - true || false:どちらかがtrueであれば全体がtrue
+    - false || false:どちらもfalseならfalse
+    - true || true || false:最初のtrueで評価終了、つまりtrue
+
+```
+// name、area、customerEvaluationがすべてnullまたは空文字列または半角スペースである場合にfalseを返す->各変数がnullまたは空文字列または半角スペースである場合に成立
+if ((name == null || name.isBlank()) && (area == null || area.isBlank()) && (impression == null || impression.isBlank())) {
+    return false;
+    
+// name、area、customerEvaluationのうち少なくとも1つが空文字列または半角スペースである場合にもfalseを返す->いずれかの変数が空文字列または半角スペースである場合に条件が成立    
+} else if (name.isBlank() || area.isBlank() || impression.isBlank()) {
+    return false;
+}
+// どちらにも当てはまらない場合にtrueを返す->全ての変数がnull,空文字,半角スペースではない場合
+return true;
+```
+
+```
+.extracting(
+    violation -> violation.getPropertyPath().toString(), // プロパティのパスを文字列に変換
+    ConstraintViolation::getMessage // 制約違反のメッセージを取得
+)
+.containsExactlyInAnyOrder(
+    tuple(
+        "nameOrAreaOrImpression", // 期待されるプロパティのパス
+        "name, area, impressionのいずれかを入力してください" // 期待されるエラーメッセージ
+    )
+);
+```

--- a/NOTE/correlationRequiredValidationPattern.md
+++ b/NOTE/correlationRequiredValidationPattern.md
@@ -72,3 +72,8 @@ return true;
     )
 );
 ```
+
+## SkiresortPatchFormTestの目的
+
+- データ更新時にname,area,impressionの全てを入力しなくて良いために作成
+- SkiresortPatchFormクラスを新規作成し、相関項目チェックできるように実装

--- a/README.md
+++ b/README.md
@@ -171,8 +171,10 @@ GitHub Actionsでワークフローを自動化する
 
 ## ブランチ:feature_51/correlationRequiredValidation
 
-- SkiresortCreateForm:バリデーションテスト
-- SkiresortPatchForm:相関項目のチェックテスト
+- SkiresortCreateForm:登録時のバリデーションテスト
+    - 登録時にはname,area,impression全ての項目の入力が必要である
+- SkiresortPatchForm:更新時の相関項目のチェックテスト
+    - 更新時にはname,area,impressionの全てを入力しなくてもバリデーションエラーとならないように実装
 
 ## 実装順理由
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,11 @@ GitHub Actionsでワークフローを自動化する
 
 - insertテストに期待値を追記
 
+## ブランチ:feature_51/correlationRequiredValidation
+
+- SkiresortCreateForm:バリデーションテスト
+- SkiresortPatchForm:相関項目のチェックテスト
+
 ## 実装順理由
 
 | 順番 | 機能                 | 理由                                                  |

--- a/src/main/java/com/example/skiresortapi/controller/SkiresortController.java
+++ b/src/main/java/com/example/skiresortapi/controller/SkiresortController.java
@@ -1,7 +1,7 @@
 package com.example.skiresortapi.controller;
 
 import com.example.skiresortapi.controller.form.SkiresortCreateForm;
-import com.example.skiresortapi.controller.form.SkiresortUpdateForm;
+import com.example.skiresortapi.controller.form.SkiresortPatchForm;
 import com.example.skiresortapi.controller.response.SkiresortResponse;
 import com.example.skiresortapi.entity.Skiresort;
 import com.example.skiresortapi.service.SkiresortService;
@@ -54,8 +54,7 @@ public class SkiresortController {
     }
 
     @PatchMapping("/skiresorts/{id}")
-    public ResponseEntity<Map<String, String>> update(@PathVariable("id") int id, @RequestBody @Valid SkiresortUpdateForm form) {
-
+    public ResponseEntity<Map<String, String>> update(@PathVariable("id") int id, @RequestBody @Valid SkiresortPatchForm form) {
         // id以外のSkiresortUpdateFormの情報を使用してレコードを更新する
         skiresortService.updateSkiresort(id, form.getName(), form.getArea(), form.getImpression());
         return ResponseEntity.ok(Map.of("message", "successfully update"));

--- a/src/main/java/com/example/skiresortapi/controller/form/SkiresortPatchForm.java
+++ b/src/main/java/com/example/skiresortapi/controller/form/SkiresortPatchForm.java
@@ -1,17 +1,14 @@
 package com.example.skiresortapi.controller.form;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.AssertTrue;
 
-public class SkiresortUpdateForm {
+public class SkiresortPatchForm {
 
-    @NotBlank
     private final String name;
-    @NotBlank
     private String area;
-    @NotBlank
     private String impression;
 
-    public SkiresortUpdateForm(String name, String area, String impression) {
+    public SkiresortPatchForm(String name, String area, String impression) {
         this.name = name;
         this.area = area;
         this.impression = impression;
@@ -36,5 +33,11 @@ public class SkiresortUpdateForm {
 
     public void setImpression(String impression) {
         this.impression = impression;
+    }
+
+    @AssertTrue(message = "name, area, impressionのいずれかを入力してください")
+    public boolean isNameOrAreaOrImpression() {
+        // name,area,impressionの全てがnullまたは空文字または半角スペースの時にfalse(バリデーション)を返す
+        return (name != null && !name.isBlank()) || (area != null && !area.isBlank()) || (impression != null && !impression.isBlank());
     }
 }

--- a/src/main/java/com/example/skiresortapi/controller/form/SkiresortPatchForm.java
+++ b/src/main/java/com/example/skiresortapi/controller/form/SkiresortPatchForm.java
@@ -15,12 +15,18 @@ public class SkiresortPatchForm {
     }
 
     // skiresortUpdateFormクラスのインスタンスからidを取得するため引数なし
+
+    /**
+     * スキーリゾート名を取得する
+     *
+     * @return スキーリゾート名
+     */
     public String getName() {
-        return name;
+        return this.name;
     }
 
     public String getArea() {
-        return area;
+        return this.area;
     }
 
     public void setArea(String area) {
@@ -28,16 +34,30 @@ public class SkiresortPatchForm {
     }
 
     public String getImpression() {
-        return impression;
+        return this.impression;
     }
 
     public void setImpression(String impression) {
         this.impression = impression;
     }
 
+    /**
+     * @AssertTrue:相関項目のチェック
+     * @return:falseの際にバリデーションを返す
+     */
     @AssertTrue(message = "name, area, impressionのいずれかを入力してください")
     public boolean isNameOrAreaOrImpression() {
         // name,area,impressionの全てがnullまたは空文字または半角スペースの時にfalse(バリデーション)を返す
-        return (name != null && !name.isBlank()) || (area != null && !area.isBlank()) || (impression != null && !impression.isBlank());
+        return isNotBlank(this.name) || isNotBlank(this.area) || isNotBlank(this.impression);
+    }
+
+    /**
+     * 空白チェック
+     *
+     * @param value チェック項目
+     * @return true:空白ではない false:空白
+     */
+    private boolean isNotBlank(String value) {
+        return value != null && !value.isBlank();
     }
 }

--- a/src/main/java/com/example/skiresortapi/service/SkiresortService.java
+++ b/src/main/java/com/example/skiresortapi/service/SkiresortService.java
@@ -12,6 +12,14 @@ public interface SkiresortService {
 
     Skiresort createSkiresort(SkiresortCreateForm skiresortCreateForm);
 
+    /**
+     * 指定されたIDのスキーリゾートを更新する
+     *
+     * @param id
+     * @param name
+     * @param area
+     * @param impression
+     */
     void updateSkiresort(int id, String name, String area, String impression);
 
     void deleteSkiresort(int id);

--- a/src/main/java/com/example/skiresortapi/service/SkiresortServiceImpl.java
+++ b/src/main/java/com/example/skiresortapi/service/SkiresortServiceImpl.java
@@ -5,10 +5,14 @@ import com.example.skiresortapi.entity.Skiresort;
 import com.example.skiresortapi.exception.ResourceNotFoundException;
 import com.example.skiresortapi.mapper.SkiresortMapper;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * スキーリゾートService
+ */
 @Service
 public class SkiresortServiceImpl implements SkiresortService {
 
@@ -32,6 +36,7 @@ public class SkiresortServiceImpl implements SkiresortService {
     }
 
     @Override
+    @Transactional
     public Skiresort createSkiresort(SkiresortCreateForm skiresortCreateForm) {
         Skiresort skiresort = new Skiresort(
                 0, // idの仮初期値として設定
@@ -45,6 +50,7 @@ public class SkiresortServiceImpl implements SkiresortService {
     }
 
     @Override
+    @Transactional
     public void updateSkiresort(int id, String name, String area, String impression) {
         Skiresort skiresort = this.skiresortMapper.findById(id).orElseThrow(() -> new ResourceNotFoundException("resource not found"));
         skiresort.setName(name);
@@ -55,6 +61,7 @@ public class SkiresortServiceImpl implements SkiresortService {
     }
 
     @Override
+    @Transactional
     public void deleteSkiresort(int id) {
         // 指定されたIDが見つからない場合に例外をスローする
         // skiresort変数に格納せずに、直接skiresortMapper.findById(id)の結果を返す

--- a/src/test/java/com/example/skiresortapi/controller/form/SkiresortCreateFormTest.java
+++ b/src/test/java/com/example/skiresortapi/controller/form/SkiresortCreateFormTest.java
@@ -18,7 +18,7 @@ class SkiresortCreateFormTest {
 
     // 一番最初に一度だけ実行される
     @BeforeAll
-    public static void setUpBalidation() {
+    public static void setUpValidator() {
         Locale.setDefault(Locale.JAPANESE);
         ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
         validator = factory.getValidator();
@@ -43,7 +43,7 @@ class SkiresortCreateFormTest {
         }
 
         @Test
-        public void nameが1文字以上である時バリデーションエラーとならないこと() {
+        public void nameが1文字である時バリデーションエラーとならないこと() {
             SkiresortCreateForm createForm = new SkiresortCreateForm("a", "Canada", "The scenery was very beautiful");
             var violations = validator.validate(createForm);
             assertThat(violations).isEmpty();
@@ -59,11 +59,11 @@ class SkiresortCreateFormTest {
         @Test
         public void nameが21文字である時バリデーションエラーとなること() {
             SkiresortCreateForm createForm = new SkiresortCreateForm("aaaaaaaaaaaaaaaaaaaaa", "Canada", "The scenery was very beautiful");
-            var violations = validator.validate((createForm));
-            // バリデーションが1つ発生することの検証
+            var violations = validator.validate(createForm);
+            // バリデーションエラーが1つ発生することの検証
             assertThat(violations).hasSize(1);
             assertThat(violations)
-                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getPropertyPath)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
                     .containsExactlyInAnyOrder(
                             tuple("name", "1 から 20 の間のサイズにしてください")
                     );
@@ -74,8 +74,18 @@ class SkiresortCreateFormTest {
     class NameNotBlankTest {
 
         @Test
-        public void nameがブランクである時バリデーションエラーとなること() {
+        public void nameが半角ブランクである時バリデーションエラーとなること() {
             SkiresortCreateForm createForm = new SkiresortCreateForm(" ", "Canada", "The scenery was very beautiful");
+            var violations = validator.validate(createForm);
+            assertThat(violations).hasSize(1);
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(tuple("name", "空白は許可されていません"));
+        }
+
+        @Test
+        public void nameがnullである時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm(null, "Canada", "The scenery was very beautiful");
             var violations = validator.validate(createForm);
             assertThat(violations).hasSize(1);
             assertThat(violations)
@@ -146,11 +156,11 @@ class SkiresortCreateFormTest {
             assertThat(violations).hasSize(1);
             assertThat(violations)
                     .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
-                    .containsExactlyInAnyOrder(tuple("impression", "空白は許可されていません"));
+                    .containsExactlyInAnyOrder(tuple("area", "空白は許可されていません"));
         }
 
         @Test
-        public void areがnullである時バリデーションエラーとなること() {
+        public void areaがnullである時バリデーションエラーとなること() {
             SkiresortCreateForm createForm = new SkiresortCreateForm("Thredbo Supertrail", null, "Australia's widest ski slope");
             var violations = validator.validate(createForm);
             assertThat(violations).hasSize(1);
@@ -160,7 +170,7 @@ class SkiresortCreateFormTest {
         }
 
         @Test
-        public void areaが全角ブランクである場合バリデーションエラーとならないこと() {
+        public void areaが全角ブランクである時バリデーションエラーとならないこと() {
             SkiresortCreateForm createForm = new SkiresortCreateForm("Thredbo Supertrail", "　", "Australia's widest ski slope");
             var violations = validator.validate(createForm);
             assertThat(violations).isEmpty();
@@ -174,6 +184,7 @@ class SkiresortCreateFormTest {
         public void impressionが1文字未満である時バリデーションエラーとなること() {
             SkiresortCreateForm createForm = new SkiresortCreateForm("Mt.Hutt", "New Zealand", "");
             var violations = validator.validate(createForm);
+            assertThat(violations).hasSize(2);
             assertThat(violations)
                     .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
                     .containsExactlyInAnyOrder(

--- a/src/test/java/com/example/skiresortapi/controller/form/SkiresortCreateFormTest.java
+++ b/src/test/java/com/example/skiresortapi/controller/form/SkiresortCreateFormTest.java
@@ -206,4 +206,33 @@ class SkiresortCreateFormTest {
                     .containsExactlyInAnyOrder(tuple("impression", "1 から 50 の間のサイズにしてください"));
         }
     }
+
+    @Nested
+    class ImpressionNotBlankTest {
+
+        @Test
+        public void impressionが半角ブランクである時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Mt.Hutt", "New Zealand", " ");
+            var violations = validator.validate(createForm);
+            assertThat(violations).hasSize(1)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(tuple("impression", "空白は許可されていません"));
+        }
+
+        @Test
+        public void impressionがnullである時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Mt.Hutt", "New Zealand", null);
+            var violations = validator.validate(createForm);
+            assertThat(violations).hasSize(1)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(tuple("impression", "空白は許可されていません"));
+        }
+
+        @Test
+        public void impressionが全角ブランクである時バリデーションエラーとならないこと() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Mt.Hutt", "New Zealand", "　");
+            var violations = validator.validate(createForm);
+            assertThat(violations).isEmpty();
+        }
+    }
 }

--- a/src/test/java/com/example/skiresortapi/controller/form/SkiresortCreateFormTest.java
+++ b/src/test/java/com/example/skiresortapi/controller/form/SkiresortCreateFormTest.java
@@ -26,6 +26,7 @@ class SkiresortCreateFormTest {
 
     @Nested
     class SkiresortNameSizeTest {
+
         @Test
         public void nameが1文字未満である時バリデーションエラーとなること() {
 
@@ -87,6 +88,51 @@ class SkiresortCreateFormTest {
             SkiresortCreateForm createForm = new SkiresortCreateForm("　", "Canada", "The scenery was very beautiful");
             var violations = validator.validate(createForm);
             assertThat(violations).isEmpty();
+        }
+    }
+
+    @Nested
+    class AreaSizeTest {
+
+        @Test
+        public void areaが1文字未満である時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Thredbo Supertrail", "", "Australia's widest ski slope");
+            var violations = validator.validate(createForm);
+            assertThat(violations).hasSize(2);
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    // 特定の条件が順不要で一致することの検証
+                    .containsExactlyInAnyOrder(
+                            tuple("area", "空白は許可されていません"),
+                            tuple("area", "1 から 20 の間のサイズにしてください")
+                    );
+        }
+
+        @Test
+        public void areaが1文字である時バリデーションエラーとならないこと() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Thredbo Supertrail", "a", "Australia's widest ski slope");
+            var violations = validator.validate(createForm);
+            // エラーなしであることの検証
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        public void areaが20文字である時バリデーションエラーとならないこと() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Thredbo Supertrail", "12345678901234567890", "Australia's widest ski slope");
+            var violations = validator.validate(createForm);
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        public void areaが21文字である時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Thredbo Supertrail", "123456789012345678901", "Australia's widest ski slope");
+            var violations = validator.validate(createForm);
+            assertThat(violations).hasSize(1);
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(
+                            tuple("area", "1 から 20 の間のサイズにしてください")
+                    );
         }
     }
 }

--- a/src/test/java/com/example/skiresortapi/controller/form/SkiresortCreateFormTest.java
+++ b/src/test/java/com/example/skiresortapi/controller/form/SkiresortCreateFormTest.java
@@ -1,0 +1,73 @@
+package com.example.skiresortapi.controller.form;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+
+class SkiresortCreateFormTest {
+    private static Validator validator;
+
+    // 一番最初に一度だけ実行される
+    @BeforeAll
+    public static void setUpBalidation() {
+        Locale.setDefault(Locale.JAPANESE);
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Nested
+    class SkiresortNameSizeTest {
+        @Test
+        public void nameが1文字未満である時バリデーションエラーとなること() {
+
+            SkiresortCreateForm createForm = new SkiresortCreateForm("", "Canada", "The scenery was very beautiful");
+            var violations = validator.validate(createForm);
+            // バリデーションが2つ発生することの検証
+            assertThat(violations).hasSize(2);
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(
+                            tuple("name", "空白は許可されていません"),
+                            tuple("name", "1 から 20 の間のサイズにしてください")
+                    );
+        }
+
+        @Test
+        public void nameが1文字以上である時バリデーションエラーとならないこと() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("a", "Canada", "The scenery was very beautiful");
+            var violations = validator.validate(createForm);
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        public void nameが20文字である時バリデーションエラーとならないこと() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("aaaaaaaaaaaaaaaaaaaa", "Canada", "The scenery was very beautiful");
+            var violations = validator.validate(createForm);
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        public void nameが21文字である時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("aaaaaaaaaaaaaaaaaaaaa", "Canada", "The scenery was very beautiful");
+            var violations = validator.validate((createForm));
+            // バリデーションが1つ発生することの検証
+            assertThat(violations).hasSize(1);
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getPropertyPath)
+                    .containsExactlyInAnyOrder(
+                            tuple("name", "1 から 20 の間のサイズにしてください")
+                    );
+        }
+    }
+
+
+}

--- a/src/test/java/com/example/skiresortapi/controller/form/SkiresortCreateFormTest.java
+++ b/src/test/java/com/example/skiresortapi/controller/form/SkiresortCreateFormTest.java
@@ -69,5 +69,24 @@ class SkiresortCreateFormTest {
         }
     }
 
+    @Nested
+    class NameNotBlankTest {
 
+        @Test
+        public void nameがブランクである時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm(" ", "Canada", "The scenery was very beautiful");
+            var violations = validator.validate(createForm);
+            assertThat(violations).hasSize(1);
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(tuple("name", "空白は許可されていません"));
+        }
+
+        @Test
+        public void nameが全角ブランクである時バリデーションエラーとならないこと() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("　", "Canada", "The scenery was very beautiful");
+            var violations = validator.validate(createForm);
+            assertThat(violations).isEmpty();
+        }
+    }
 }

--- a/src/test/java/com/example/skiresortapi/controller/form/SkiresortCreateFormTest.java
+++ b/src/test/java/com/example/skiresortapi/controller/form/SkiresortCreateFormTest.java
@@ -166,4 +166,44 @@ class SkiresortCreateFormTest {
             assertThat(violations).isEmpty();
         }
     }
+
+    @Nested
+    class ImpressionSizeTest {
+
+        @Test
+        public void impressionが1文字未満である時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Mt.Hutt", "New Zealand", "");
+            var violations = validator.validate(createForm);
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(
+                            tuple("impression", "空白は許可されていません"),
+                            tuple("impression", "1 から 50 の間のサイズにしてください")
+                    );
+        }
+
+        @Test
+        public void impressionが1文字である時バリデーションエラーとならないこと() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Mt.Hutt", "New Zealand", "1");
+            var violations = validator.validate(createForm);
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        public void impressionが50文字である時バリデーションエラーとならないこと() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Mt.Hutt", "New Zealand", "12345678901234567890123456789012345678901234567890");
+            var violations = validator.validate(createForm);
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        public void impressionが51文字である時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Mt.Hutt", "New Zealand", "123456789012345678901234567890123456789012345678901");
+            var violations = validator.validate(createForm);
+            assertThat(violations).hasSize(1);
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(tuple("impression", "1 から 50 の間のサイズにしてください"));
+        }
+    }
 }

--- a/src/test/java/com/example/skiresortapi/controller/form/SkiresortCreateFormTest.java
+++ b/src/test/java/com/example/skiresortapi/controller/form/SkiresortCreateFormTest.java
@@ -135,4 +135,35 @@ class SkiresortCreateFormTest {
                     );
         }
     }
+
+    @Nested
+    class AreaNotBlankTest {
+
+        @Test
+        public void areaが半角ブランクである時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Thredbo Supertrail", " ", "Australia's widest ski slope");
+            var violations = validator.validate(createForm);
+            assertThat(violations).hasSize(1);
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(tuple("impression", "空白は許可されていません"));
+        }
+
+        @Test
+        public void areがnullである時バリデーションエラーとなること() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Thredbo Supertrail", null, "Australia's widest ski slope");
+            var violations = validator.validate(createForm);
+            assertThat(violations).hasSize(1);
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(tuple("area", "空白は許可されていません"));
+        }
+
+        @Test
+        public void areaが全角ブランクである場合バリデーションエラーとならないこと() {
+            SkiresortCreateForm createForm = new SkiresortCreateForm("Thredbo Supertrail", "　", "Australia's widest ski slope");
+            var violations = validator.validate(createForm);
+            assertThat(violations).isEmpty();
+        }
+    }
 }

--- a/src/test/java/com/example/skiresortapi/controller/form/SkiresortPatchFormTest.java
+++ b/src/test/java/com/example/skiresortapi/controller/form/SkiresortPatchFormTest.java
@@ -174,10 +174,47 @@ class SkiresortPatchFormTest {
 
         @Test
         public void areaのみが半角スペースの場合バリデーションエラーとならないこと() {
-            SkiresortPatchForm patchForm = new SkiresortPatchForm("Lake Louise", "", "Ski the World Heritage Site of the Canadian Rockies");
+            SkiresortPatchForm patchForm = new SkiresortPatchForm("Lake Louise", " ", "Ski the World Heritage Site of the Canadian Rockies");
 
             Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
             assertThat(violations).isEmpty();
+        }
+
+        @Test
+        public void impressionのみが半角スペースの場合バリデーションエラーとならないこと() {
+            SkiresortPatchForm patchForm = new SkiresortPatchForm("Lake Louise", "Canada", "");
+
+            Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
+            assertThat(violations).isEmpty();
+        }
+    }
+
+    @Nested
+    class OkPatternTest {
+
+        @Test
+        void name以外がnullと空文字の時バリデーションエラーとならないこと() {
+            SkiresortPatchForm patchForm = new SkiresortPatchForm("Lake Louise", null, "");
+
+            Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        void area以外がnullと空文字の時バリデーションエラーとならないこと() {
+            SkiresortPatchForm patchForm = new SkiresortPatchForm(null, "Canada", " ");
+
+            Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        void imperssion以外がnullと空文字の時バリデーションエラーとならないこと() {
+            SkiresortPatchForm patchForm = new SkiresortPatchForm("", " ", "Ski the World Heritage Site of the Canadian Rockies");
+
+            Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
+            assertThat(violations).isEmpty();
+
         }
     }
 

--- a/src/test/java/com/example/skiresortapi/controller/form/SkiresortPatchFormTest.java
+++ b/src/test/java/com/example/skiresortapi/controller/form/SkiresortPatchFormTest.java
@@ -32,7 +32,9 @@ class SkiresortPatchFormTest {
             SkiresortPatchForm patchForm = new SkiresortPatchForm(null, null, null);
 
             Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
-            assertThat(violations).hasSize(1)
+            assertThat(violations).hasSize(1);
+            // 制約違反(ConstraintViolation)情報でどのプロパティに関連しているか、エラーメッセージが何かを検証する
+            assertThat(violations)
                     .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
                     .containsExactlyInAnyOrder(
                             tuple("nameOrAreaOrImpression", "name, area, impressionのいずれかを入力してください")
@@ -61,6 +63,50 @@ class SkiresortPatchFormTest {
 
             Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
             assertThat(violations).isEmpty();
+        }
+    }
+
+    @Nested
+    class EmptyStringTest {
+
+        @Test
+        public void nameとareaとimpressionの全て空文字の時にバリデーションエラーとなること() {
+            SkiresortPatchForm patchForm = new SkiresortPatchForm("", "", "");
+
+            Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
+            assertThat(violations).hasSize(1);
+            // 制約違反(ConstraintViolation)情報でどのプロパティに関連しているか、エラーメッセージが何かを検証する
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(
+                            tuple("nameOrAreaOrImpression", "name, area, impressionのいずれかを入力してください")
+                    );
+        }
+
+        @Test
+        public void areaのみがnullの時にバリデーションエラーとならないこと() {
+            SkiresortPatchForm patchForm = new SkiresortPatchForm(null, "Canada", "Ski the World Heritage Site of the Canadian Rockies");
+
+            Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        public void areaのみがnullの場合バリデーションエラーとならないこと() {
+            SkiresortPatchForm patchForm = new SkiresortPatchForm("Lake Louise", null, "Ski the World Heritage Site of the Canadian Rockies");
+
+            Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        public void impressionのみがnullの時バリデーションエラーとならないこと() {
+            SkiresortPatchForm patchForm = new SkiresortPatchForm("Lake Louise", "Canada", null);
+
+            Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
+            assertThat(violations).isEmpty();
+
+
         }
     }
 

--- a/src/test/java/com/example/skiresortapi/controller/form/SkiresortPatchFormTest.java
+++ b/src/test/java/com/example/skiresortapi/controller/form/SkiresortPatchFormTest.java
@@ -1,0 +1,5 @@
+package com.example.skiresortapi.controller.form;
+
+class SkiresortPatchFormTest {
+
+}

--- a/src/test/java/com/example/skiresortapi/controller/form/SkiresortPatchFormTest.java
+++ b/src/test/java/com/example/skiresortapi/controller/form/SkiresortPatchFormTest.java
@@ -28,7 +28,7 @@ class SkiresortPatchFormTest {
     class NullTest {
 
         @Test
-        public void nameとareaとimpressionの全てがnullの時にバリデーションエラーとなること() {
+        public void nameとareaとimpressionの全てがnullの時バリデーションエラーとなること() {
             SkiresortPatchForm patchForm = new SkiresortPatchForm(null, null, null);
 
             Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
@@ -42,7 +42,7 @@ class SkiresortPatchFormTest {
         }
 
         @Test
-        public void nameのみがnullの時にバリデーションエラーとならないこと() {
+        public void nameのみがnullの時バリデーションエラーとならないこと() {
             SkiresortPatchForm patchForm = new SkiresortPatchForm(null, "Canada", "Ski the World Heritage Site of the Canadian Rockies");
 
             Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
@@ -50,50 +50,8 @@ class SkiresortPatchFormTest {
         }
 
         @Test
-        public void areaのみがnullの時にバリデーションエラーとならないこと() {
+        public void areaのみがnullの時バリデーションエラーとならないこと() {
             SkiresortPatchForm patchForm = new SkiresortPatchForm("Lake Louise", null, "Ski the World Heritage Site of the Canadian Rockies");
-
-            Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
-            assertThat(violations).isEmpty();
-        }
-
-        @Test
-        public void impressionのみがnullの時にバリデーションエラーとならないこと() {
-            SkiresortPatchForm patchForm = new SkiresortPatchForm("Lake Louise", "Canada", null);
-
-            Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
-            assertThat(violations).isEmpty();
-        }
-    }
-
-    @Nested
-    class EmptyStringTest {
-
-        @Test
-        public void nameとareaとimpressionの全て空文字の時にバリデーションエラーとなること() {
-            SkiresortPatchForm patchForm = new SkiresortPatchForm("", "", "");
-
-            Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
-            assertThat(violations).hasSize(1);
-            // 制約違反(ConstraintViolation)情報でどのプロパティに関連しているか、エラーメッセージが何かを検証する
-            assertThat(violations)
-                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
-                    .containsExactlyInAnyOrder(
-                            tuple("nameOrAreaOrImpression", "name, area, impressionのいずれかを入力してください")
-                    );
-        }
-
-        @Test
-        public void areaのみが空文字の時にバリデーションエラーとならないこと() {
-            SkiresortPatchForm patchForm = new SkiresortPatchForm("", "Canada", "Ski the World Heritage Site of the Canadian Rockies");
-
-            Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
-            assertThat(violations).isEmpty();
-        }
-
-        @Test
-        public void impressionのみが空文字の場合バリデーションエラーとならないこと() {
-            SkiresortPatchForm patchForm = new SkiresortPatchForm("Lake Louise", "Canada", "");
 
             Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
             assertThat(violations).isEmpty();
@@ -109,15 +67,17 @@ class SkiresortPatchFormTest {
     }
 
     @Nested
-    class EmptyTest {
-        public void nameとareaとimpressionが全て空文字の時バリデーションエラーとなること() {
+    class EmptyStringTest {
+
+        @Test
+        public void nameとareaとimpressionの全て空文字の時バリデーションエラーとなること() {
             SkiresortPatchForm patchForm = new SkiresortPatchForm("", "", "");
 
             Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
             assertThat(violations).hasSize(1);
             // 制約違反(ConstraintViolation)情報でどのプロパティに関連しているか、エラーメッセージが何かを検証する
             assertThat(violations)
-                    .extracting(violation -> violation.getPropertyPath(), ConstraintViolation::getMessage)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
                     .containsExactlyInAnyOrder(
                             tuple("nameOrAreaOrImpression", "name, area, impressionのいずれかを入力してください")
                     );
@@ -132,15 +92,16 @@ class SkiresortPatchFormTest {
         }
 
         @Test
-        public void areaのみがnullの時バリデーションエラーとならないこと() {
+        public void areaのみが空文字の時バリデーションエラーとならないこと() {
             SkiresortPatchForm patchForm = new SkiresortPatchForm("Lake Louise", "", "Ski the World Heritage Site of the Canadian Rockies");
 
             Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
             assertThat(violations).isEmpty();
         }
 
+
         @Test
-        public void impressionのみがnullの時バリデーションエラーとならないこと() {
+        public void impressionのみが空文字の時バリデーションエラーとならないこと() {
             SkiresortPatchForm patchForm = new SkiresortPatchForm("Lake Louise", "Canada", "");
 
             Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
@@ -152,7 +113,7 @@ class SkiresortPatchFormTest {
     class BlankTest {
 
         @Test
-        public void nameとareaとimpressionが全て半角スペースの場合バリデーションエラーとなること() {
+        public void nameとareaとimpressionが全て半角スペースの時バリデーションエラーとなること() {
             SkiresortPatchForm patchForm = new SkiresortPatchForm(" ", " ", " ");
 
             Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
@@ -165,7 +126,7 @@ class SkiresortPatchFormTest {
         }
 
         @Test
-        public void nameのみが半角スペースの場合バリデーションエラーとならないこと() {
+        void nameのみが半角スペースの時バリデーションエラーとならないこと() {
             SkiresortPatchForm patchForm = new SkiresortPatchForm(" ", "Canada", "Ski the World Heritage Site of the Canadian Rockies");
 
             Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
@@ -173,7 +134,7 @@ class SkiresortPatchFormTest {
         }
 
         @Test
-        public void areaのみが半角スペースの場合バリデーションエラーとならないこと() {
+        void areaのみが半角スペースの時バリデーションエラーとならないこと() {
             SkiresortPatchForm patchForm = new SkiresortPatchForm("Lake Louise", " ", "Ski the World Heritage Site of the Canadian Rockies");
 
             Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
@@ -181,7 +142,7 @@ class SkiresortPatchFormTest {
         }
 
         @Test
-        public void impressionのみが半角スペースの場合バリデーションエラーとならないこと() {
+        void impressionのみが半角スペースの時バリデーションエラーとならないこと() {
             SkiresortPatchForm patchForm = new SkiresortPatchForm("Lake Louise", "Canada", "");
 
             Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
@@ -201,7 +162,7 @@ class SkiresortPatchFormTest {
         }
 
         @Test
-        void area以外がnullと空文字の時バリデーションエラーとならないこと() {
+        void area以外がnullと半角スペースの時バリデーションエラーとならないこと() {
             SkiresortPatchForm patchForm = new SkiresortPatchForm(null, "Canada", " ");
 
             Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
@@ -209,13 +170,11 @@ class SkiresortPatchFormTest {
         }
 
         @Test
-        void imperssion以外がnullと空文字の時バリデーションエラーとならないこと() {
+        void imperssion以外が空文字と半角スペースの時バリデーションエラーとならないこと() {
             SkiresortPatchForm patchForm = new SkiresortPatchForm("", " ", "Ski the World Heritage Site of the Canadian Rockies");
 
             Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
             assertThat(violations).isEmpty();
-
         }
     }
-
 }

--- a/src/test/java/com/example/skiresortapi/controller/form/SkiresortPatchFormTest.java
+++ b/src/test/java/com/example/skiresortapi/controller/form/SkiresortPatchFormTest.java
@@ -84,16 +84,16 @@ class SkiresortPatchFormTest {
         }
 
         @Test
-        public void areaのみがnullの時にバリデーションエラーとならないこと() {
-            SkiresortPatchForm patchForm = new SkiresortPatchForm(null, "Canada", "Ski the World Heritage Site of the Canadian Rockies");
+        public void areaのみが空文字の時にバリデーションエラーとならないこと() {
+            SkiresortPatchForm patchForm = new SkiresortPatchForm("", "Canada", "Ski the World Heritage Site of the Canadian Rockies");
 
             Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
             assertThat(violations).isEmpty();
         }
 
         @Test
-        public void areaのみがnullの場合バリデーションエラーとならないこと() {
-            SkiresortPatchForm patchForm = new SkiresortPatchForm("Lake Louise", null, "Ski the World Heritage Site of the Canadian Rockies");
+        public void impressionのみが空文字の場合バリデーションエラーとならないこと() {
+            SkiresortPatchForm patchForm = new SkiresortPatchForm("Lake Louise", "Canada", "");
 
             Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
             assertThat(violations).isEmpty();
@@ -111,7 +111,7 @@ class SkiresortPatchFormTest {
     @Nested
     class EmptyTest {
         public void nameとareaとimpressionが全て空文字の時バリデーションエラーとなること() {
-            SkiresortPatchForm patchForm = new SkiresortPatchForm(" ", " ", " ");
+            SkiresortPatchForm patchForm = new SkiresortPatchForm("", "", "");
 
             Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
             assertThat(violations).hasSize(1);
@@ -142,6 +142,39 @@ class SkiresortPatchFormTest {
         @Test
         public void impressionのみがnullの時バリデーションエラーとならないこと() {
             SkiresortPatchForm patchForm = new SkiresortPatchForm("Lake Louise", "Canada", "");
+
+            Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
+            assertThat(violations).isEmpty();
+        }
+    }
+
+    @Nested
+    class BlankTest {
+
+        @Test
+        public void nameとareaとimpressionが全て半角スペースの場合バリデーションエラーとなること() {
+            SkiresortPatchForm patchForm = new SkiresortPatchForm(" ", " ", " ");
+
+            Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
+            assertThat(violations).hasSize(1);
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(
+                            tuple("nameOrAreaOrImpression", "name, area, impressionのいずれかを入力してください")
+                    );
+        }
+
+        @Test
+        public void nameのみが半角スペースの場合バリデーションエラーとならないこと() {
+            SkiresortPatchForm patchForm = new SkiresortPatchForm(" ", "Canada", "Ski the World Heritage Site of the Canadian Rockies");
+
+            Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        public void areaのみが半角スペースの場合バリデーションエラーとならないこと() {
+            SkiresortPatchForm patchForm = new SkiresortPatchForm("Lake Louise", "", "Ski the World Heritage Site of the Canadian Rockies");
 
             Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
             assertThat(violations).isEmpty();

--- a/src/test/java/com/example/skiresortapi/controller/form/SkiresortPatchFormTest.java
+++ b/src/test/java/com/example/skiresortapi/controller/form/SkiresortPatchFormTest.java
@@ -1,0 +1,67 @@
+package com.example.skiresortapi.controller.form;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+
+
+class SkiresortPatchFormTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    public static void setUpValidator() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Nested
+    class NullTest {
+
+        @Test
+        public void nameとareaとimpressionの全てがnullの時にバリデーションエラーとなること() {
+            SkiresortPatchForm patchForm = new SkiresortPatchForm(null, null, null);
+
+            Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
+            assertThat(violations).hasSize(1)
+                    .extracting(violation -> violation.getPropertyPath().toString(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(
+                            tuple("nameOrAreaOrImpression", "name, area, impressionのいずれかを入力してください")
+                    );
+        }
+
+        @Test
+        public void nameのみがnullの時にバリデーションエラーとならないこと() {
+            SkiresortPatchForm patchForm = new SkiresortPatchForm(null, "Canada", "Ski the World Heritage Site of the Canadian Rockies");
+
+            Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        public void areaのみがnullの時にバリデーションエラーとならないこと() {
+            SkiresortPatchForm patchForm = new SkiresortPatchForm("Lake Louise", null, "Ski the World Heritage Site of the Canadian Rockies");
+
+            Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        public void impressionのみがnullの時にバリデーションエラーとならないこと() {
+            SkiresortPatchForm patchForm = new SkiresortPatchForm("Lake Louise", "Canada", null);
+
+            Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
+            assertThat(violations).isEmpty();
+        }
+    }
+
+}

--- a/src/test/java/com/example/skiresortapi/controller/form/SkiresortPatchFormTest.java
+++ b/src/test/java/com/example/skiresortapi/controller/form/SkiresortPatchFormTest.java
@@ -1,5 +1,0 @@
-package com.example.skiresortapi.controller.form;
-
-class SkiresortPatchFormTest {
-
-}

--- a/src/test/java/com/example/skiresortapi/controller/form/SkiresortPatchFormTest.java
+++ b/src/test/java/com/example/skiresortapi/controller/form/SkiresortPatchFormTest.java
@@ -105,8 +105,46 @@ class SkiresortPatchFormTest {
 
             Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
             assertThat(violations).isEmpty();
+        }
+    }
 
+    @Nested
+    class EmptyTest {
+        public void nameとareaとimpressionが全て空文字の時バリデーションエラーとなること() {
+            SkiresortPatchForm patchForm = new SkiresortPatchForm(" ", " ", " ");
 
+            Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
+            assertThat(violations).hasSize(1);
+            // 制約違反(ConstraintViolation)情報でどのプロパティに関連しているか、エラーメッセージが何かを検証する
+            assertThat(violations)
+                    .extracting(violation -> violation.getPropertyPath(), ConstraintViolation::getMessage)
+                    .containsExactlyInAnyOrder(
+                            tuple("nameOrAreaOrImpression", "name, area, impressionのいずれかを入力してください")
+                    );
+        }
+
+        @Test
+        public void nameのみが空文字の時バリデーションエラーとならないこと() {
+            SkiresortPatchForm patchForm = new SkiresortPatchForm("", "Canada", "Ski the World Heritage Site of the Canadian Rockies");
+
+            Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        public void areaのみがnullの時バリデーションエラーとならないこと() {
+            SkiresortPatchForm patchForm = new SkiresortPatchForm("Lake Louise", "", "Ski the World Heritage Site of the Canadian Rockies");
+
+            Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        public void impressionのみがnullの時バリデーションエラーとならないこと() {
+            SkiresortPatchForm patchForm = new SkiresortPatchForm("Lake Louise", "Canada", "");
+
+            Set<ConstraintViolation<SkiresortPatchForm>> violations = validator.validate(patchForm);
+            assertThat(violations).isEmpty();
         }
     }
 


### PR DESCRIPTION
# フィールドの更新時に相関項目のチェックをする

## 実装内容
- `@NotBlank`:フィールド単項目のチェック
- `@AssertTrue`:相関項目のチェック。更新時は1つでも項目が入力されていれば、バリデーションエラーとならない

## 迷ったこと
- correlationRequiredValidationPattern.mdに全パターンを書き出して、バリデーションとならないパターンをどこまで実装すべきか

## 確認ポイント
- GitHub Actions:テストレポートが自動生成されること

## 動作確認キャプチャ
![81D1F76A-BBD0-421C-84CA-02BA183FDF0F_1_201_a](https://github.com/yoko-newDeveloper/skiresortapi/assets/91002836/1b32d4eb-413b-4f19-bfaa-8d30d71ade12)