### PR TITLE
feature_57/errorMessage-fix:エラーメッセージの変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,16 @@ GitHub Actionsでワークフローを自動化する
 
 - メソッドにJavaDocコメントを追加
 
+## ブランチ:feature_feature_55/eception-fix
+
+- exceptionディレクトリのConstomExceptionHandlerを2つのクラスに分割する
+
+## ブランチ:feature_57/errorMessage-fix
+
+- エラーメッセージ`resource not found`を具体的な名前`skiresort not found`に変更
+    - SkiresortRestApiIntegrationTest
+    - SkiresortServiceImpl
+
 ## 実装順理由
 
 | 順番 | 機能                 | 理由                                                  |

--- a/src/main/java/com/example/skiresortapi/service/SkiresortServiceImpl.java
+++ b/src/main/java/com/example/skiresortapi/service/SkiresortServiceImpl.java
@@ -43,7 +43,7 @@ public class SkiresortServiceImpl implements SkiresortService {
     @Override
     public Skiresort findById(int id) {
         Optional<Skiresort> skiresort = this.skiresortMapper.findById(id);
-        return skiresort.orElseThrow(() -> new ResourceNotFoundException("resource not found"));
+        return skiresort.orElseThrow(() -> new ResourceNotFoundException("skiresort not found"));
     }
 
     /**
@@ -77,7 +77,7 @@ public class SkiresortServiceImpl implements SkiresortService {
     @Override
     @Transactional
     public void updateSkiresort(int id, String name, String area, String impression) {
-        Skiresort skiresort = this.skiresortMapper.findById(id).orElseThrow(() -> new ResourceNotFoundException("resource not found"));
+        Skiresort skiresort = this.skiresortMapper.findById(id).orElseThrow(() -> new ResourceNotFoundException("skiresort not found"));
         skiresort.setName(name);
         skiresort.setArea(area);
         skiresort.setImpression(impression);
@@ -95,7 +95,7 @@ public class SkiresortServiceImpl implements SkiresortService {
     public void deleteSkiresort(int id) {
         // 指定されたIDが見つからない場合に例外をスローする
         // skiresort変数に格納せずに、直接skiresortMapper.findById(id)の結果を返す
-        skiresortMapper.findById(id).orElseThrow(() -> new ResourceNotFoundException("resource not found"));
+        skiresortMapper.findById(id).orElseThrow(() -> new ResourceNotFoundException("skiresort not found"));
         skiresortMapper.deleteSkiresort(id);
     }
 }

--- a/src/test/java/com/example/skiresortapi/integrationtest/SkiresortRestApiIntegrationTest.java
+++ b/src/test/java/com/example/skiresortapi/integrationtest/SkiresortRestApiIntegrationTest.java
@@ -167,7 +167,7 @@ public class SkiresortRestApiIntegrationTest {
                     {
                         "path": "/skiresorts/100",
                         "status": "404",
-                        "message": "resource not found",
+                        "message": "skiresort not found",
                         "timestamp": "2024-03-10T20:48.123456789+09:00[JST/Tokyo]",
                         "error": "Not Found"
                     }
@@ -207,7 +207,7 @@ public class SkiresortRestApiIntegrationTest {
                     {
                         "path": "/skiresorts/5",
                         "status": "404",
-                        "message": "resource not found",
+                        "message": "skiresort not found",
                         "timestamp": "2024-03-10T22:00:00:123456789+09:00[JST/Tokyo]",
                         "error": "Not Found"
                     }

--- a/src/test/java/com/example/skiresortapi/service/SkiresortServiceImplTest.java
+++ b/src/test/java/com/example/skiresortapi/service/SkiresortServiceImplTest.java
@@ -77,7 +77,7 @@ class SkiresortServiceImplTest {
             assertThatThrownBy(() -> skiresortServiceImpl.findById(100)) // テスト対象メソッド
                     // throwされる例外がResourceNotFoundException（リソースがないことを通知する）を返す
                     .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessage("resource not found");
+                    .hasMessage("skiresort not found");
             verify(skiresortMapper, times(1)).findById(100);
         }
     }
@@ -133,14 +133,14 @@ class SkiresortServiceImplTest {
             // updateSkiresortメソッドを実行した時にthrowされる例外がResourceNotFoundExceptionクラスのインスタンスであることを期待している
             assertThatThrownBy(() -> skiresortServiceImpl.updateSkiresort(100, "Coronet Peak", "NZ", "海外遠征で初めて滑ったスキー場。すごく広くてクイーンズタウンからも近い")) // テスト対象メソッド
                     .isInstanceOf(ResourceNotFoundException.class)
-                    .hasMessage("resource not found");
+                    .hasMessage("skiresort not found");
             verify(skiresortMapper, times(1)).findById(100);
         }
     }
 
     @Nested
     class DeleteSkiresortTest {
-        
+
         @Test
         public void 指定したIDのスキーリゾート情報を削除できること() {
             doReturn(Optional.of(new Skiresort(1, "白馬乗鞍", "長野県", "初めてペンションに居候として山籠りし、初めて草大会に出場した思い出のゲレンデ"))).when(skiresortMapper).findById(1);


### PR DESCRIPTION
# エラーメッセージ`resource not found`を具体的なメッセージに変更する

## 変更クラス
- SkiresortRestApiIntegrationTest
- SkiresortServiceImpl

## 動作確認ポイント
- GitHub Actions:テストレポートが自動生成されること

## 動作確認キャプチャ
![3D035261-F92E-490C-A09E-7F5511CD6EE9_1_105_c](https://github.com/yoko-newDeveloper/skiresortapi/assets/91002836/4394f8d1-f3a7-435c-aa93-841c302003b0)
![517E2906-8600-4DE1-8692-1B89F8EE3D1D_1_105_c](https://github.com/yoko-newDeveloper/skiresortapi/assets/91002836/b662e9ef-8e1f-465c-aa43-edfe392f1edd)
